### PR TITLE
Temporary fix for private zone having 2 VPC's

### DIFF
--- a/global/r53.tf
+++ b/global/r53.tf
@@ -17,6 +17,10 @@ resource "aws_route53_zone" "main_priv" {
   vpc {
     vpc_id = "${module.prodvpc.vpc_id}"
   }
+
+  lifecycle {
+    ignore_changes = ["vpc"]
+  }
 }
 
 #Associate Stage VPC with Internal DNS


### PR DESCRIPTION
@gravesm I don't think this is the solution for passing the workspace to the shared module. But maybe I'm missing something.

This also may be a 1 off example, but it keeps spitting out:
`aws_route53_zone.main_priv`
`      vpc.#:                 "2" => "1"
`      vpc.1456677164.vpc_id: "vpc-08570f01ad05eda51" => ""
`      vpc.2007137398.vpc_id: "vpc-06ba9c4510342054e" => "vpc-06ba9c4510342054e"
`

Without an ignore.. 