### PR TITLE
Add TF Config for grandchallenges CDN + S3

### DIFF
--- a/apps/grandchallenges/grandchallenges.tf
+++ b/apps/grandchallenges/grandchallenges.tf
@@ -1,0 +1,21 @@
+#The certificate was created manually (via MIT) and imported manually
+#We will investigate options for generating SSL certificates in the future
+
+module "grand_web" {
+  source               = "git::https://github.com/mitlibraries/tf-mod-cdn-s3?ref=initial"
+  name                 = "grandchallenges"
+  aliases              = ["grandchallenges.mitlib.net"]
+  ext_aliases          = ["grandchallenges.mit.edu"]
+  parent_zone_name     = "mitlib.net"
+  cors_allowed_origins = ["grandchallenges.mit.edu"]
+
+  custom_error_response = [
+    {
+      error_code         = "404"
+      response_code      = "200"
+      response_page_path = "/index.html"
+    },
+  ]
+
+  acm_certificate_arn = "arn:aws:acm:us-east-1:672626379771:certificate/cdb62536-c66f-4eff-940a-d90ecc869b0b"
+}

--- a/apps/grandchallenges/main.tf
+++ b/apps/grandchallenges/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  version = "~> 1.47.0"
+  region  = "us-east-1"
+}
+
+#Tell terraform to use the S3 bucket and DynamoDB we created
+terraform {
+  required_version = ">= 0.11.10"
+
+  backend "s3" {
+    region         = "us-east-1"
+    bucket         = "mit-tfstates-state"
+    key            = "apps/grandchallenges.tfstate"
+    dynamodb_table = "mit-tfstates-state-lock"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
This adds the TF config for the grandchallenges.mit.edu website to use our CDN/S3 module
*This has been setup in Prod workspace
*DNS changes have been requested to point to grandchallenges.mitlib.net