### PR TITLE
Create S3 bucket and IAM user for use with Aleph dump

### DIFF
--- a/apps/DIP/dip.tf
+++ b/apps/DIP/dip.tf
@@ -1,0 +1,28 @@
+module "label" {
+  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  name   = "DIP-aleph-S3"
+}
+
+module "alephs3" {
+  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  name               = "DIP-aleph-S3"
+  access             = "readwrite"
+  versioning_enabled = "true"
+}
+
+#create our AWS user to access the S3 Bucket
+resource "aws_iam_user" "default" {
+  name          = "${module.label.name}-${module.alephs3.access}"
+  path          = "/"
+  force_destroy = "false"
+}
+
+resource "aws_iam_user_policy_attachment" "default_rw" {
+  user       = "${aws_iam_user.default.name}"
+  policy_arn = "${module.alephs3.readwrite_arn[0]}"
+}
+
+# Generate API credentials
+resource "aws_iam_access_key" "default" {
+  user = "${aws_iam_user.default.name}"
+}

--- a/apps/DIP/main.tf
+++ b/apps/DIP/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  version = "~> 1.47.0"
+  region  = "us-east-1"
+}
+
+#Tell terraform to use the S3 bucket and DynamoDB we created
+terraform {
+  required_version = ">= 0.11.10"
+
+  backend "s3" {
+    region         = "us-east-1"
+    bucket         = "mit-tfstates-state"
+    key            = "apps/dip.tfstate"
+    dynamodb_table = "mit-tfstates-state-lock"
+    encrypt        = true
+  }
+}

--- a/apps/DIP/outputs.tf
+++ b/apps/DIP/outputs.tf
@@ -1,0 +1,10 @@
+output "access_key_id" {
+  value       = "${aws_iam_access_key.default.id}"
+  description = "The access key ID"
+}
+
+output "secret_access_key" {
+  value       = "${aws_iam_access_key.default.secret}"
+  sensitive   = true
+  description = "The secret access key. This will be written to the state file in plain-text"
+}


### PR DESCRIPTION
* S3 bucket creation for stage environment
* To be used with an S3sync script that will put Aleph dumps in S3