### PR TITLE
Adds Route53 DNS for simile and dpworkshop

### DIFF
--- a/global/r53.tf
+++ b/global/r53.tf
@@ -33,3 +33,115 @@ resource "aws_route53_zone_association" "stage" {
   zone_id = "${aws_route53_zone.main_priv.zone_id}"
   vpc_id  = "${module.stagevpc.vpc_id}"
 }
+
+# Add hosted zone and DNS entry for simile-widgets.org
+resource "aws_route53_zone" "simile" {
+  name = "simile-widgets.org"
+
+  tags = {
+    terraform   = "true"
+    environment = "global"
+    Name        = "simile-widgets.org"
+  }
+}
+
+resource "aws_route53_record" "simile-ns" {
+  zone_id = "${aws_route53_zone.simile.zone_id}"
+  name    = "${aws_route53_zone.simile.name}"
+  type    = "NS"
+  ttl     = "300"
+
+  records = [
+    "${aws_route53_zone.simile.name_servers.0}",
+    "${aws_route53_zone.simile.name_servers.1}",
+    "${aws_route53_zone.simile.name_servers.2}",
+    "${aws_route53_zone.simile.name_servers.3}",
+  ]
+}
+
+resource "aws_route53_record" "simile-soa" {
+  zone_id = "${aws_route53_zone.simile.id}"
+  name    = "${aws_route53_zone.simile.name}"
+  type    = "SOA"
+  ttl     = "300"
+
+  records = [
+    "${aws_route53_zone.simile.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
+  ]
+}
+
+resource "aws_route53_record" "simile-web" {
+  zone_id = "${aws_route53_zone.simile.id}"
+  name    = "${aws_route53_zone.simile.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["18.9.49.52"]
+}
+
+resource "aws_route53_record" "simile-trunk" {
+  zone_id = "${aws_route53_zone.simile.id}"
+  name    = "trunk.${aws_route53_zone.simile.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["18.9.49.116"]
+}
+
+resource "aws_route53_record" "simile-service" {
+  zone_id = "${aws_route53_zone.simile.id}"
+  name    = "service.${aws_route53_zone.simile.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["18.9.49.117"]
+}
+
+resource "aws_route53_record" "simile-api" {
+  zone_id = "${aws_route53_zone.simile.id}"
+  name    = "api.${aws_route53_zone.simile.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["18.9.49.118"]
+}
+
+# Add hosted zone and DNS entry for dpworkshop.org
+resource "aws_route53_zone" "dpworkshop" {
+  name = "dpworkshop.org"
+
+  tags = {
+    terraform   = "true"
+    environment = "global"
+    Name        = "dpworkshop.org"
+  }
+}
+
+resource "aws_route53_record" "dpworkshop-ns" {
+  zone_id = "${aws_route53_zone.dpworkshop.zone_id}"
+  name    = "${aws_route53_zone.dpworkshop.name}"
+  type    = "NS"
+  ttl     = "300"
+
+  records = [
+    "${aws_route53_zone.dpworkshop.name_servers.0}",
+    "${aws_route53_zone.dpworkshop.name_servers.1}",
+    "${aws_route53_zone.dpworkshop.name_servers.2}",
+    "${aws_route53_zone.dpworkshop.name_servers.3}",
+  ]
+}
+
+resource "aws_route53_record" "dpworkshop-soa" {
+  zone_id = "${aws_route53_zone.dpworkshop.id}"
+  name    = "${aws_route53_zone.dpworkshop.name}"
+  type    = "SOA"
+  ttl     = "300"
+
+  records = [
+    "${aws_route53_zone.dpworkshop.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
+  ]
+}
+
+resource "aws_route53_record" "dpworkshop-web" {
+  zone_id = "${aws_route53_zone.dpworkshop.id}"
+  name    = "${aws_route53_zone.dpworkshop.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["18.9.49.70"]
+}


### PR DESCRIPTION
This creates the hosted zones for these 2 domains as we plan to consolidate and migrate these to Route53.

@vab Can you ensure Route53 entries are correct before we proceed with the migration?

Post migration and verification we should increase the TTL for NS and SOA of these domains. The low TTL is a safety precaution in case something goes wrong.