### PR TITLE
Moves ES domain policy for write access to dip

### DIFF
--- a/shared/elasticsearch/elasticsearch.tf
+++ b/shared/elasticsearch/elasticsearch.tf
@@ -13,35 +13,3 @@ module "elasticsearch" {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 }
-
-##################################################################
-# Create ES policy doc to allow write access from NAT Public IPs #
-# Re-evaluate this when adding indices from other applications   #
-##################################################################
-data "aws_iam_policy_document" "default" {
-  statement {
-    actions = ["es:*"]
-
-    resources = [
-      "${module.elasticsearch.arn}",
-      "${module.elasticsearch.arn}/*",
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "IpAddress"
-      variable = "aws:SourceIp"
-
-      values = ["${module.shared.nat_public_ips}"]
-    }
-  }
-}
-
-resource "aws_elasticsearch_domain_policy" "default" {
-  domain_name     = "${module.elasticsearch.domain_name}"
-  access_policies = "${data.aws_iam_policy_document.default.json}"
-}

--- a/shared/elasticsearch/main.tf
+++ b/shared/elasticsearch/main.tf
@@ -15,7 +15,3 @@ terraform {
     encrypt        = true
   }
 }
-
-module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
-}

--- a/shared/elasticsearch/outputs.tf
+++ b/shared/elasticsearch/outputs.tf
@@ -17,3 +17,8 @@ output "write_policy_arn" {
   description = "Default domain write policy ARN"
   value       = "${module.elasticsearch.write_policy_arn}"
 }
+
+output "domain_name" {
+  description = "Domain name of cluster"
+  value       = "${module.elasticsearch.domain_name}"
+}


### PR DESCRIPTION
* Moves ES domain policy from shared/elasticsearch to dip app
* Re-evaluate later as this isn't ideal, but the best temporary solution for now