### PR TITLE
Create Lambda cloudwatch group in Terraform

### DIFF
--- a/apps/DIP/dip.tf
+++ b/apps/DIP/dip.tf
@@ -362,6 +362,11 @@ resource "aws_security_group" "default" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${module.mario-label.name}-lambda"
+  retention_in_days = 30
+}
+
 resource "aws_lambda_function" "default" {
   function_name = "${module.mario-label.name}-lambda"
   s3_bucket     = "${aws_s3_bucket.lambda_s3.id}"


### PR DESCRIPTION
Previously we relying on the Lambda to auto-create the log group. This doesn't appear to be working so we will create with TF.