### PR TITLE
Add author lookup module

### DIFF
--- a/apps/author_lookup/README.md
+++ b/apps/author_lookup/README.md
@@ -1,0 +1,22 @@
+# Author Lookup API
+
+This module contains partial configuration for the Author Lookup API. The following items are created:
+
+* Lambda exection role
+* Travis deploy user
+* S3 bucket for Lambda
+* Secret used by API
+
+The rest of the AWS resources are created/managed by zappa during deploy.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| access\_key\_id | Access key for deploy user |
+| bucket\_name | Name of Lambda bucket |
+| deploy\_user | Name of the IAM deploy user |
+| role\_arn | ARN for Zappa execution role |
+| secret\_access\_key | Secret key for deploy user |
+| secrets\_arn | ARN for author lookup secrets |
+

--- a/apps/author_lookup/author_lookup.tf
+++ b/apps/author_lookup/author_lookup.tf
@@ -1,0 +1,172 @@
+module "label" {
+  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  name   = "author-lookup"
+}
+
+module "bucket" {
+  source = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  name   = "author-lookup"
+}
+
+module "secret" {
+  source = "git::https://github.com/mitlibraries/tf-mod-secrets?ref=master"
+  name   = "author-lookup"
+}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    actions = [
+      "logs:*",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "lambda:InvokeFunction",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:AttachNetworkInterface",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeInstances",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DetachNetworkInterface",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:ResetNetworkInterfaceAttribute",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "kinesis:*",
+    ]
+
+    resources = [
+      "arn:aws:kinesis:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sns:*",
+    ]
+
+    resources = [
+      "arn:aws:sns:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sqs:*",
+    ]
+
+    resources = [
+      "arn:aws:sqs:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:*",
+    ]
+
+    resources = [
+      "arn:aws:dynamodb:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "route53:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals = {
+      type = "Service"
+
+      identifiers = [
+        "apigateway.amazonaws.com",
+        "lambda.amazonaws.com",
+        "events.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "default" {
+  name   = "${module.label.name}-lambda"
+  role   = "${aws_iam_role.default.name}"
+  policy = "${data.aws_iam_policy_document.default.json}"
+}
+
+resource "aws_iam_role" "default" {
+  name               = "${module.label.name}-lambda"
+  assume_role_policy = "${data.aws_iam_policy_document.assume.json}"
+  description        = "Role used by author lookup lambda"
+  tags               = "${module.label.tags}"
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = "${aws_iam_role.default.name}"
+  policy_arn = "${module.secret.read_policy}"
+}
+
+resource "aws_iam_user" "default" {
+  name = "${module.label.name}-deploy"
+  tags = "${module.label.tags}"
+}
+
+resource "aws_iam_user_policy_attachment" "default" {
+  user       = "${aws_iam_user.default.name}"
+  policy_arn = "${module.bucket.readwrite_arn}"
+}
+
+resource "aws_iam_access_key" "default" {
+  user = "${aws_iam_user.default.name}"
+}

--- a/apps/author_lookup/main.tf
+++ b/apps/author_lookup/main.tf
@@ -1,0 +1,28 @@
+/**
+ * # Author Lookup API
+ *
+ * This module contains partial configuration for the Author Lookup API. The following items are created:
+ *
+ * * Lambda exection role
+ * * Travis deploy user
+ * * S3 bucket for Lambda
+ * * Secret used by API
+ *
+ * The rest of the AWS resources are created/managed by zappa during deploy.
+ **/
+provider "aws" {
+  version = "~> 1.56.0 "
+  region  = "us-east-1"
+}
+
+terraform {
+  required_version = ">= 0.11.10"
+
+  backend "s3" {
+    region         = "us-east-1"
+    bucket         = "mit-tfstates-state"
+    key            = "apps/author_lookup.tfstate"
+    dynamodb_table = "mit-tfstates-state-lock"
+    encrypt        = true
+  }
+}

--- a/apps/author_lookup/outputs.tf
+++ b/apps/author_lookup/outputs.tf
@@ -1,0 +1,29 @@
+output "bucket_name" {
+  value       = "${module.bucket.bucket_id}"
+  description = "Name of Lambda bucket"
+}
+
+output "deploy_user" {
+  value       = "${aws_iam_user.default.name}"
+  description = "Name of the IAM deploy user"
+}
+
+output "access_key_id" {
+  value       = "${aws_iam_access_key.default.id}"
+  description = "Access key for deploy user"
+}
+
+output "secret_access_key" {
+  value       = "${aws_iam_access_key.default.secret}"
+  description = "Secret key for deploy user"
+}
+
+output "role_arn" {
+  value       = "${aws_iam_role.default.arn}"
+  description = "ARN for Zappa execution role"
+}
+
+output "secrets_arn" {
+  value       = "${module.secret.secret}"
+  description = "ARN for author lookup secrets"
+}


### PR DESCRIPTION
This adds partial TF config for the author lookup module. It would be
nice to have a Zappa module that handles all the TF config, but this at
least manages the S3 bucket and IAM.