### PR TITLE
Creates a security group allowing ingress on all ports from ALB

### DIFF
--- a/shared/network/alb.tf
+++ b/shared/network/alb.tf
@@ -1,5 +1,7 @@
+#######################
+### Restricted ALB ###
+######################
 #Creates default restricted (18.0.0.0/9) ALB that uses *.mitlib.net cert by default
-
 module "alb_restricted" {
   source                    = "git::https://github.com/mitlibraries/tf-mod-alb?ref=master"
   name                      = "alb-restricted"
@@ -12,4 +14,30 @@ module "alb_restricted" {
   access_logs_region        = "${var.aws_region}"
   https_enabled             = "true"
   certificate_arn           = "${module.shared.mitlib_cert}"
+}
+
+module "sg_label" {
+  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  name   = "alb-restricted"
+}
+
+# Create default security group to allow all ingress from restricted ALB
+module "all_access_from_alb" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "2.13.0"
+
+  name        = "${module.alb_restricted.alb_name} all Ingress"
+  description = "Allow all ingress from restricted ALB"
+  vpc_id      = "${module.shared.vpc_id}"
+
+  ingress_with_source_security_group_id = [
+    {
+      from_port                = 0
+      to_port                  = 0
+      protocol                 = "-1"
+      source_security_group_id = "${module.alb_restricted.security_group_id}"
+    },
+  ]
+
+  tags = "${module.sg_label.tags}"
 }

--- a/shared/network/outputs.tf
+++ b/shared/network/outputs.tf
@@ -64,3 +64,8 @@ output "alb_restricted_https_listener_arn" {
   description = "Restricted ALB HTTPS listener ARN"
   value       = "${module.alb_restricted.https_listener_arn}"
 }
+
+output "alb_restricted_all_ingress_sgid" {
+  description = "Restricted ALB security group ID allowing all ingress traffic from ALB"
+  value       = "${module.all_access_from_alb.this_security_group_id}"
+}


### PR DESCRIPTION
* This will be used for apps behind our ALB
* It is more secure than the original CIDR block of allowing all internal traffic
* This will only allow traffic from the ALB to a resource (for example the Cantaloupe container)