### PR TITLE
Create public ALB and default ingress sg from ALB

### DIFF
--- a/shared/network/alb.tf
+++ b/shared/network/alb.tf
@@ -30,7 +30,7 @@ module "all_access_from_alb" {
   description = "Allow all ingress from restricted ALB"
   vpc_id      = "${module.shared.vpc_id}"
 
-  ingress_with_source_security_group_id = [
+  computed_ingress_with_source_security_group_id = [
     {
       from_port                = 0
       to_port                  = 0
@@ -39,5 +39,50 @@ module "all_access_from_alb" {
     },
   ]
 
-  tags = "${module.sg_label.tags}"
+  number_of_computed_ingress_with_source_security_group_id = 1
+  tags                                                     = "${module.sg_label.tags}"
+}
+
+#########################
+### Public Facing ALB ###
+#########################
+#Creates default public ALB that uses *.mitlib.net cert by default
+module "alb_public" {
+  source              = "git::https://github.com/mitlibraries/tf-mod-alb?ref=master"
+  name                = "alb-public"
+  vpc_id              = "${module.vpc.vpc_id}"
+  ip_address_type     = "ipv4"
+  subnet_ids          = ["${module.vpc.public_subnets}"]
+  access_logs_enabled = "false"
+  access_logs_region  = "${var.aws_region}"
+  https_enabled       = "true"
+  certificate_arn     = "${module.shared.mitlib_cert}"
+}
+
+module "sg_label_public" {
+  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  name   = "alb-public"
+}
+
+# Create default security group to allow all ingress from public ALB
+
+module "all_access_from_alb_public" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "2.13.0"
+
+  name        = "${module.alb_public.alb_name} all Ingress"
+  description = "Allow all ingress from restricted ALB"
+  vpc_id      = "${module.shared.vpc_id}"
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      from_port                = 0
+      to_port                  = 0
+      protocol                 = "-1"
+      source_security_group_id = "${module.alb_public.security_group_id}"
+    },
+  ]
+
+  number_of_computed_ingress_with_source_security_group_id = 1
+  tags                                                     = "${module.sg_label_public.tags}"
 }

--- a/shared/network/outputs.tf
+++ b/shared/network/outputs.tf
@@ -25,6 +25,8 @@ output "nat_public_ips" {
 ######################
 #####ALB OUTPUTS #####
 ######################
+
+# Restricted
 output "alb_restricted_arn" {
   description = "Restricted ALB arn"
   value       = "${module.alb_restricted.alb_arn}"
@@ -68,4 +70,50 @@ output "alb_restricted_https_listener_arn" {
 output "alb_restricted_all_ingress_sgid" {
   description = "Restricted ALB security group ID allowing all ingress traffic from ALB"
   value       = "${module.all_access_from_alb.this_security_group_id}"
+}
+
+# Public
+output "alb_public_arn" {
+  description = "Public ALB arn"
+  value       = "${module.alb_public.alb_arn}"
+}
+
+output "alb_public_arn_suffix" {
+  description = "The ARN suffix of the ALB"
+  value       = "${module.alb_public.alb_arn_suffix}"
+}
+
+output "alb_public_name" {
+  description = "Public ALB name"
+  value       = "${module.alb_public.alb_name}"
+}
+
+output "alb_public_dnsname" {
+  description = "Public ALB DNS name"
+  value       = "${module.alb_public.alb_dns_name}"
+}
+
+output "alb_public_sgid" {
+  description = "Public ALB security group ID"
+  value       = "${module.alb_public.security_group_id}"
+}
+
+output "alb_public_default_target_group_arn" {
+  description = "Public ALB default target group arn"
+  value       = "${module.alb_public.default_target_group_arn}"
+}
+
+output "alb_public_http_listener_arn" {
+  description = "Public ALB HTTP listener ARN"
+  value       = "${module.alb_public.http_listener_arn}"
+}
+
+output "alb_public_https_listener_arn" {
+  description = "Public ALB HTTPS listener ARN"
+  value       = "${module.alb_public.https_listener_arn}"
+}
+
+output "alb_public_all_ingress_sgid" {
+  description = "Public ALB security group ID allowing all ingress traffic from ALB"
+  value       = "${module.all_access_from_alb_public.this_security_group_id}"
 }


### PR DESCRIPTION
* Public ALB creation
* Switched to "computed_ingress_with_source_security_group" so it can be created at the same time as ALB. Without "computed", it requires that the ALB already exist.