### PR TITLE
Add deploy user

### DIFF
--- a/apps/carbon/carbon.tf
+++ b/apps/carbon/carbon.tf
@@ -227,3 +227,26 @@ resource "aws_sns_topic" "instance-alerts" {
     command = "aws sns subscribe --topic-arn ${self.arn} --protocol email --notification-endpoint ${var.email}"
   }
 }
+
+###################
+### Deploy user ###
+###################
+
+resource "aws_iam_user" "deploy" {
+  name = "${module.label.name}-deploy"
+  tags = "${module.label.tags}"
+}
+
+resource "aws_iam_user_policy_attachment" "deploy_s3" {
+  user       = "${aws_iam_user.deploy.name}"
+  policy_arn = "${module.shared.deploy_rw_arn}"
+}
+
+resource "aws_iam_user_policy_attachment" "deploy_ecr" {
+  user       = "${aws_iam_user.deploy.name}"
+  policy_arn = "${module.ecr.policy_readwrite_arn}"
+}
+
+resource "aws_iam_access_key" "deploy" {
+  user = "${aws_iam_user.deploy.name}"
+}

--- a/apps/carbon/main.tf
+++ b/apps/carbon/main.tf
@@ -28,3 +28,7 @@ data "aws_subnet" "mit_net" {
 data "aws_vpc" "mit_net_vpc" {
   id = "vpc-0ef9d327814ed449d"
 }
+
+module "shared" {
+  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+}

--- a/apps/carbon/outputs.tf
+++ b/apps/carbon/outputs.tf
@@ -1,0 +1,15 @@
+output "deploy_user" {
+  value       = "${aws_iam_user.deploy.name}"
+  description = "Name of the IAM deploy user"
+}
+
+output "access_key_id" {
+  value       = "${aws_iam_access_key.deploy.id}"
+  description = "Access key for deploy user"
+}
+
+output "secret_access_key" {
+  value       = "${aws_iam_access_key.deploy.secret}"
+  description = "Secret key for deploy user"
+  sensitive   = true
+}


### PR DESCRIPTION
This had originally been set up to use a manually configured deploy user
a while ago. This change adds a deploy user to the TF config and sets up
permissions to use the shared S3 deploy bucket.