### PR TITLE
Set secret key output to be sensitive

### DIFF
--- a/apps/author_lookup/author_lookup.tf
+++ b/apps/author_lookup/author_lookup.tf
@@ -3,10 +3,6 @@ module "label" {
   name   = "author-lookup"
 }
 
-module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
-}
-
 module "bucket" {
   source = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
   name   = "author-lookup"

--- a/apps/author_lookup/main.tf
+++ b/apps/author_lookup/main.tf
@@ -26,3 +26,7 @@ terraform {
     encrypt        = true
   }
 }
+
+module "shared" {
+  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+}

--- a/apps/author_lookup/outputs.tf
+++ b/apps/author_lookup/outputs.tf
@@ -16,6 +16,7 @@ output "access_key_id" {
 output "secret_access_key" {
   value       = "${aws_iam_access_key.default.secret}"
   description = "Secret key for deploy user"
+  sensitive   = true
 }
 
 output "role_arn" {


### PR DESCRIPTION
This sets the secret key output to be sensitive and moves the shared
module to main.tf.