### PR TITLE
Prepare for migration of FoL to Pantheon

### DIFF
--- a/apps/futureoflibraries/README.md
+++ b/apps/futureoflibraries/README.md
@@ -1,0 +1,9 @@
+# Future of Libraries
+
+This folder contains AWS Route53 records for the Future of Libraries Drupal site hosted on [Pantheon](https://pantheon.io/).
+
+### What's created?:
+* 3 x Route53 DNS records for dev, test, and live
+
+### Additional Info:
+* Future of Libraries is only deployed to the Terraform `prod` workspace

--- a/apps/futureoflibraries/fol.tf
+++ b/apps/futureoflibraries/fol.tf
@@ -1,0 +1,23 @@
+resource "aws_route53_record" "fol" {
+  name    = "future-of-libraries"
+  ttl     = 300
+  type    = "A"
+  zone_id = "${module.shared.public_zoneid}"
+  records = ["18.9.49.56"]
+}
+
+resource "aws_route53_record" "fol_dev" {
+  name    = "future-of-libraries-dev"
+  ttl     = 300
+  type    = "CNAME"
+  zone_id = "${module.shared.public_zoneid}"
+  records = ["dev-mitlib-futureoflibraries.pantheonsite.io"]
+}
+
+resource "aws_route53_record" "fol_test" {
+  name    = "future-of-libraries-test"
+  ttl     = 300
+  type    = "A"
+  zone_id = "${module.shared.public_zoneid}"
+  records = ["18.9.49.57"]
+}

--- a/apps/futureoflibraries/main.tf
+++ b/apps/futureoflibraries/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  version = "~> 1.56.0 "
+  region  = "us-east-1"
+}
+
+#Tell terraform to use the S3 bucket and DynamoDB we created
+terraform {
+  required_version = ">= 0.11.10"
+
+  backend "s3" {
+    region         = "us-east-1"
+    bucket         = "mit-tfstates-state"
+    key            = "apps/fol.tfstate"
+    dynamodb_table = "mit-tfstates-state-lock"
+    encrypt        = true
+  }
+}
+
+module "shared" {
+  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+}


### PR DESCRIPTION
This is an initial config so we don't have to rely on central IT for DNS changes.

* mit.edu DNS have been requested to point to mitlib.net
* Will update mitlib.net DNS when we're ready to cut over to Pantheon