### PR TITLE
Upgrade AWS Provider

### DIFF
--- a/apps/DIP/main.tf
+++ b/apps/DIP/main.tf
@@ -15,7 +15,7 @@
  * The Elasticsearch search index is created in the [shared module](https://github.com/MITLibraries/mitlib-terraform/tree/master/shared/elasticsearch).
  */
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/author_lookup/main.tf
+++ b/apps/author_lookup/main.tf
@@ -11,7 +11,7 @@
  * The rest of the AWS resources are created/managed by zappa during deploy.
  **/
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/cantaloupe/main.tf
+++ b/apps/cantaloupe/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/carbon/main.tf
+++ b/apps/carbon/main.tf
@@ -5,7 +5,7 @@
  **/
 
 provider "aws" {
-  version = "~> 1.56.0"
+  version = "~> 1.60.0"
   region  = "us-east-1"
 }
 

--- a/apps/ebooks/main.tf
+++ b/apps/ebooks/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/futureoflibraries/main.tf
+++ b/apps/futureoflibraries/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/grandchallenges/main.tf
+++ b/apps/grandchallenges/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/libstaff/main.tf
+++ b/apps/libstaff/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/apps/tdr/main.tf
+++ b/apps/tdr/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/global/main.tf
+++ b/global/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/shared/bastion/main.tf
+++ b/shared/bastion/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0"
+  version = "~> 1.60.0"
   region  = "${var.aws_region}"
 }
 

--- a/shared/deploy/main.tf
+++ b/shared/deploy/main.tf
@@ -5,7 +5,7 @@
  *
  **/
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/shared/elasticsearch/main.tf
+++ b/shared/elasticsearch/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 

--- a/shared/network/main.tf
+++ b/shared/network/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.56.0 "
+  version = "~> 1.60.0 "
   region  = "us-east-1"
 }
 


### PR DESCRIPTION
Upgrade AWS provider to 1.60.0 to prep for upgrade to AWS Provider 2. (https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html)

@gravesm Let me know if you run into issues with the 1.60.0 version. I don't think we will since we were pretty close to the latest. I'm going to start looking into 2.x.0. (2.1.0 is expected to have support for 3AZ ES 😸 