### PR TITLE
Simile DNS update for api.simile-widgets.org

### DIFF
--- a/global/r53.tf
+++ b/global/r53.tf
@@ -99,7 +99,7 @@ resource "aws_route53_record" "simile-api" {
   name    = "api.${aws_route53_zone.simile.name}"
   type    = "A"
   ttl     = "300"
-  records = ["18.9.49.118"]
+  records = ["18.23.238.99"]
 }
 
 # Add hosted zone and DNS entry for dpworkshop.org


### PR DESCRIPTION
I have fixed the issue with the api.simile-widgets.org webserver configuration that was breaking Exhibits. So, we can now update the DNS to point of the AWS host.