### PR TITLE
Upgrades aws provider to 2.1.0

### DIFF
--- a/apps/DIP/main.tf
+++ b/apps/DIP/main.tf
@@ -15,7 +15,7 @@
  * The Elasticsearch search index is created in the [shared module](https://github.com/MITLibraries/mitlib-terraform/tree/master/shared/elasticsearch).
  */
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/author_lookup/main.tf
+++ b/apps/author_lookup/main.tf
@@ -11,7 +11,7 @@
  * The rest of the AWS resources are created/managed by zappa during deploy.
  **/
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/cantaloupe/main.tf
+++ b/apps/cantaloupe/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/carbon/main.tf
+++ b/apps/carbon/main.tf
@@ -5,7 +5,7 @@
  **/
 
 provider "aws" {
-  version = "~> 1.60.0"
+  version = "~> 2.1.0"
   region  = "us-east-1"
 }
 

--- a/apps/ebooks/main.tf
+++ b/apps/ebooks/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/futureoflibraries/main.tf
+++ b/apps/futureoflibraries/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/grandchallenges/main.tf
+++ b/apps/grandchallenges/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/libstaff/main.tf
+++ b/apps/libstaff/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/oatf/main.tf
+++ b/apps/oatf/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/apps/tdr/main.tf
+++ b/apps/tdr/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/global/main.tf
+++ b/global/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/shared/bastion/main.tf
+++ b/shared/bastion/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0"
+  version = "~> 2.1.0"
   region  = "${var.aws_region}"
 }
 

--- a/shared/deploy/main.tf
+++ b/shared/deploy/main.tf
@@ -5,7 +5,7 @@
  *
  **/
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/shared/elasticsearch/main.tf
+++ b/shared/elasticsearch/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 

--- a/shared/network/main.tf
+++ b/shared/network/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0 "
+  version = "~> 2.1.0 "
   region  = "us-east-1"
 }
 


### PR DESCRIPTION
[AWS Provider 2 upgrade doc](https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html)

Potential changes you may see during terraform plan or apply :
```
  ~ module.alb_ingress.aws_lb_target_group.default
      lambda_multi_value_headers_enabled: "" => "false"

  ~ module.fargate.aws_ecs_service.default
      placement_strategy.#:               "" => <computed>
```

`lambda_multi_value_headers_enabled - (Optional) Boolean whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when target_type is lambda.`

We should have no issues with this as we are currently only using `target_type = ip` for our Application load balancers

I'm not entirely sure why `placement_strategy.# = 0` gets added since it becomes deprecated in 2.1.0. However at this time we are not using it or `order_placement_strategy`, and this won't cause issues.