### PR TITLE
Adds security_group id to be used for access to instances from bastion

### DIFF
--- a/shared/bastion/bastion.tf
+++ b/shared/bastion/bastion.tf
@@ -85,3 +85,25 @@ resource "aws_route53_record" "bastion" {
   ttl     = "300"
   records = ["${aws_eip.bastion.public_ip}"]
 }
+
+resource "aws_security_group" "from_bastion_sg" {
+  description = "Access from ${module.bastion.name}"
+  vpc_id      = "${module.shared.vpc_id}"
+  name        = "ingress-from-${module.bastion.name}"
+
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = ["${module.bastion.security_group_id}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = "${module.bastion.tags}"
+}

--- a/shared/bastion/outputs.tf
+++ b/shared/bastion/outputs.tf
@@ -1,0 +1,3 @@
+output "ingress_from_bastion_sg_id" {
+  value = "${aws_security_group.from_bastion_sg.id}"
+}


### PR DESCRIPTION
Creates security group that can be assigned to instances for access from the bastion host. This could be assigned to RDS instances as well for importing databases.

Once approved, I'll add to tf-mod-shared-providers