### PR TITLE
Adds aws_backup_plan for EFS volumes

### DIFF
--- a/apps/geoweb/geoweb.tf
+++ b/apps/geoweb/geoweb.tf
@@ -70,3 +70,79 @@ resource "aws_iam_user_policy_attachment" "solrdeploy_ecr" {
 resource "aws_iam_access_key" "deploy" {
   user = "${aws_iam_user.deploy.name}"
 }
+
+###################
+### AWS Backup ###
+##################
+
+resource "aws_iam_role" "backup_role" {
+  name = "${module.label_geoweb.name}"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [
+                    "backup.amazonaws.com"
+                ]
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "attach_backup" {
+  role       = "${aws_iam_role.backup_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_restore" {
+  role       = "${aws_iam_role.backup_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+}
+
+resource "aws_kms_key" "geoweb" {
+  description = "KMS Key for ${module.label_geoweb.name} Backups"
+  tags        = "${module.label_geoweb.tags}"
+}
+
+resource "aws_backup_vault" "geoweb" {
+  name        = "${module.label_geoweb.name}"
+  kms_key_arn = "${aws_kms_key.geoweb.arn}"
+  tags        = "${module.label_geoweb.tags}"
+}
+
+resource "aws_backup_plan" "geoweb" {
+  name = "${module.label_geoweb.name}"
+
+  rule {
+    rule_name         = "${module.label_geoweb.name}"
+    target_vault_name = "${aws_backup_vault.geoweb.name}"
+    schedule          = "cron(0 5 ? * * *)"
+
+    #recovery_point_tags = "${module.label_geoweb.tags}"
+
+    lifecycle {
+      delete_after = "30"
+    }
+  }
+
+  #tags = "${module.label_geoweb.tags}"
+}
+
+resource "aws_backup_selection" "geoweb" {
+  name         = "${module.label_geoweb.name}"
+  plan_id      = "${aws_backup_plan.geoweb.id}"
+  iam_role_arn = "${aws_iam_role.backup_role.arn}"
+
+  resources = [
+    "${aws_efs_file_system.geo_efs.arn}",
+    "${aws_efs_file_system.solr_efs.arn}",
+  ]
+}


### PR DESCRIPTION
This adds backups for the Geoweb EFS volumes (Solr and Geoserver).

The `tag` arguments are currently commented out because of what appears to be an [issue](https://github.com/terraform-providers/terraform-provider-aws/issues/8193) with the terraform-aws-provider. Keep an eye on this when looking to put this in production or when finalizing backup schedules. Backups are currently working, and there are no errors or changes when running `terraform apply`, there just aren't any tags.