### PR TITLE
Configure document-services for MIT certificates stored in S3 Bucket

### DIFF
--- a/apps/document-services/variables.tf
+++ b/apps/document-services/variables.tf
@@ -9,9 +9,3 @@ variable "rds_password" {
   default     = ""
   description = "(Required unless a snapshot_identifier or replicate_source_db is provided) Password for the master DB user"
 }
-
-variable "ssl_email" {
-  type        = "string"
-  default     = ""
-  description = "E-mail Address to use for registration with Let's Encrypt"
-}


### PR DESCRIPTION
* Remove anything Let'sEncrypty
* Create a S3 bucket for manual upload of MIT certs
* Add permissions to Beanstalk service IAM role to read/get certs 
* Add annoying variables for .ebextensions configuration