### PR TITLE
Output timdex keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # .tfvars files
 *.tfvars
+.DS_Store

--- a/apps/DIP/outputs.tf
+++ b/apps/DIP/outputs.tf
@@ -19,3 +19,15 @@ output "mario_deploy_secret_access_key" {
   sensitive   = true
   description = "Secret access key for mario deploy user."
 }
+
+output "timdex_access_key_secret" {
+  value       = "${aws_iam_access_key.timdex.secret}"
+  sensitive   = true
+  description = "Secret access key for timdex user."
+}
+
+output "timdex_access_key_id" {
+  value       = "${aws_iam_access_key.timdex.id}"
+  sensitive   = true
+  description = "ID for timdex user."
+}


### PR DESCRIPTION
This outputs the keys necessary for timdex to use the es index.

`terraform show` from the appropriate workspace will now show you the keys necessary for TIMDEX! to work. The es endpoint URL is a shared resource. It would be nice to include that here too but I wasn't sure if that was a good idea so I didn't. Note: you may need to `terraform refresh` before show will, er, show you these new outputs.