### PR TITLE
Add IAM user access to bucket, switch from .tfvars to locals example

### DIFF
--- a/apps/lib-digitalobjects/lib-digitalobjects.tf
+++ b/apps/lib-digitalobjects/lib-digitalobjects.tf
@@ -1,5 +1,9 @@
 # The SSL certificate was created manually (via MIT) and imported manually
 # We will investigate options for generating SSL certificates in the future
+module "label" {
+  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  name   = "lib-digitalobjects"
+}
 
 module "lib-digitalobjects" {
   source = "git::https://github.com/mitlibraries/tf-mod-cdn-s3?ref=master"
@@ -20,4 +24,42 @@ module "lib-digitalobjects" {
   ]
 
   acm_certificate_arn = "${var.acm_certificate_arn}"
+}
+
+# Create an admin user and give access to our bucket to manage objects
+data "aws_iam_policy_document" "admin" {
+  statement {
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:GetObject", "s3:ListBucket", "s3:DeleteObject"]
+    resources = ["${module.lib-digitalobjects.s3_bucket_arn}", "${module.lib-digitalobjects.s3_bucket_arn}/*"]
+    effect    = "Allow"
+  }
+
+  #This is needed for users to be able to select the bucket
+  statement {
+    actions   = ["s3:ListAllMyBuckets"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "admin" {
+  name        = "${module.label.name}-admin"
+  description = "Policy to allow IAM user full access to ${module.label.name} S3 bucket"
+  policy      = "${data.aws_iam_policy_document.admin.json}"
+}
+
+resource "aws_iam_user" "default" {
+  name          = "${module.label.name}-admin"
+  path          = "/"
+  force_destroy = "false"
+}
+
+resource "aws_iam_user_policy_attachment" "admin" {
+  user       = "${aws_iam_user.default.name}"
+  policy_arn = "${aws_iam_policy.admin.arn}"
+}
+
+# Generate API credentials
+resource "aws_iam_access_key" "default" {
+  user = "${aws_iam_user.default.name}"
 }


### PR DESCRIPTION
* An example of how to work around using .tfvars when there's no secrets (using locals)
* Add admin user for working with files (This will be used for mapping to the S3 bucket for IASC to manage files)