### PR TITLE
Configure GeoServer and Solr tasks to use EFS

### DIFF
--- a/apps/geoweb/geoserver.tf
+++ b/apps/geoweb/geoserver.tf
@@ -53,6 +53,7 @@ data "template_file" "default" {
     image              = "${module.ecr.registry_url}"
     log_group          = "${aws_cloudwatch_log_group.default.name}"
     geoserver_password = "${aws_ssm_parameter.geoserver_password.arn}"
+    data_dir           = "/var/geoserver/data"
   }
 }
 
@@ -76,6 +77,11 @@ resource "aws_ecs_task_definition" "geoserver" {
   tags                     = "${module.label_geoserver.tags}"
   execution_role_arn       = "${aws_iam_role.geosrv_exec.arn}"
   network_mode             = "bridge"
+
+  volume {
+    name      = "geo_efs"
+    host_path = "${local.geoserver_mount}"
+  }
 }
 
 data "aws_iam_policy_document" "ssm" {

--- a/apps/geoweb/solr.tf
+++ b/apps/geoweb/solr.tf
@@ -45,6 +45,7 @@ data "template_file" "solrtask" {
     name      = "${module.label_solr.name}"
     image     = "${module.solr_ecr.registry_url}"
     log_group = "${aws_cloudwatch_log_group.solr.name}"
+    solr_home = "/var/solr"
   }
 }
 
@@ -68,6 +69,11 @@ resource "aws_ecs_task_definition" "solrtask" {
   tags                     = "${module.label_solr.tags}"
   execution_role_arn       = "${aws_iam_role.solr_exec.arn}"
   network_mode             = "bridge"
+
+  volume {
+    name      = "solr_efs"
+    host_path = "${local.solr_mount}"
+  }
 }
 
 resource "aws_iam_role" "solr_exec" {

--- a/apps/geoweb/solrtask.json
+++ b/apps/geoweb/solrtask.json
@@ -10,12 +10,23 @@
         "awslogs-stream-prefix": "geosolr"
       }
     },
+    "environment": [
+      {
+        "name": "SOLR_HOME",
+        "value": "${solr_home}"
+      }
+    ],
     "portMappings": [
       {
         "containerPort": 8983
       }
     ],
-    "memoryReservation": 1024
-
+    "memoryReservation": 1024,
+    "mountPoints": [
+      {
+        "containerPath": "${solr_home}",
+        "sourceVolume": "solr_efs"
+      }
+    ]
   }
 ]

--- a/apps/geoweb/task.json
+++ b/apps/geoweb/task.json
@@ -16,12 +16,23 @@
         "valueFrom": "${geoserver_password}"
       }
     ],
+    "environment": [
+      {
+        "name": "GEOSERVER_DATA_DIR",
+        "value": "${data_dir}"
+      }
+    ],
     "portMappings": [
       {
         "containerPort": 8080
       }
     ],
-    "memoryReservation": 1024
-
+    "memoryReservation": 1024,
+    "mountPoints": [
+      {
+        "containerPath": "${data_dir}",
+        "sourceVolume": "geo_efs"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This configures GeoServer and Solr to use the mounted EFS volumes for
their persistent storage.