### PR TITLE
Allow timdex readonly access to timdex prefixed indexes

### DIFF
--- a/apps/DIP/dip.tf
+++ b/apps/DIP/dip.tf
@@ -44,6 +44,7 @@ data "aws_iam_policy_document" "read" {
     resources = [
       "${module.shared.es_arn}/aleph*",
       "${module.shared.es_arn}/production*",
+      "${module.shared.es_arn}/timdex*",
     ]
   }
 }


### PR DESCRIPTION
Prep work for https://mitlibraries.atlassian.net/browse/DIP-225 in which we'll start using `timdex-production` instead of `production` since es is being treated as a shared resource and not only being used for timdex.

When the mario changes land and timdex ENV is updated, we should clean up the access to `"${module.shared.es_arn}/production*",`.

The plan for this in prod seems to be applying more than this change so I believe a previous commit was never applied. It specifically is adding `module.ecr.aws_iam_policy.readwrite`

