### PR TITLE
update vpn subnets for libstaff s3 bucket access

### DIFF
--- a/apps/libstaff/libstaff.tf
+++ b/apps/libstaff/libstaff.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "default" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
-      values = ["18.100.0.0/16", "18.101.0.0/16"]
+      values = ["18.28.0.0/16", "18.30.0.0/16"]
     }
   }]
 }


### PR DESCRIPTION
This is a minor code change to update the MIT VPN subnets in the IAM policy for the libstaff website archive S3 bucket access.