### PR TITLE
Remove broken bastion security group

### DIFF
--- a/shared/bastion/bastion.tf
+++ b/shared/bastion/bastion.tf
@@ -85,25 +85,3 @@ resource "aws_route53_record" "bastion" {
   ttl     = "300"
   records = ["${aws_eip.bastion.public_ip}"]
 }
-
-resource "aws_security_group" "from_bastion_sg" {
-  description = "Access from ${module.bastion.name}"
-  vpc_id      = "${module.shared.vpc_id}"
-  name        = "ingress-from-${module.bastion.name}"
-
-  ingress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    security_groups = ["${module.bastion.security_group_id}"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = "${module.bastion.tags}"
-}

--- a/shared/bastion/outputs.tf
+++ b/shared/bastion/outputs.tf
@@ -1,3 +1,3 @@
 output "ingress_from_bastion_sg_id" {
-  value = "${aws_security_group.from_bastion_sg.id}"
+  value = "${module.bastion.security_group_id}"
 }


### PR DESCRIPTION
The way this security group is being use does not work. The correct way
to provide access to a resource from the bastion host is to use the
security group associated with the bastion EC2 instance in an ingress
rule. This removes the broken security group and sets the output to the
correct security group.