### PR TITLE
Adds variables for SMTP settings

### DIFF
--- a/apps/document-services/document-services.tf
+++ b/apps/document-services/document-services.tf
@@ -101,7 +101,11 @@ module "eb_docsvcs" {
     "CERT_S3", "https://${module.s3_cert_store.bucket_domain_name}/${module.label.name}.mit.edu.crt",
     "KEY_S3", "https://${module.s3_cert_store.bucket_domain_name}/${module.label.name}.mit.edu.key",
     "CYBERSOURCE_ACCESS_KEY", "${var.cybersource_access_key}",
-    "CYBERSOURCE_PROFILE_ID", "${var.cybersource_profile_id}"
+    "CYBERSOURCE_PROFILE_ID", "${var.cybersource_profile_id}",
+    "MAIL_HOST", "${var.mail_host}",
+    "MAIL_PASSWORD", "${var.mail_password}",
+    "MAIL_PORT", "${var.mail_port}",
+    "MAIL_USERNAME", "${var.mail_username}"
     )
   }"
 }

--- a/apps/document-services/variables.tf
+++ b/apps/document-services/variables.tf
@@ -21,3 +21,27 @@ variable "cybersource_profile_id" {
   default     = ""
   description = "Identifier passed to MIT Merchant Services to ensure payments are classified correctly"
 }
+
+variable "mail_host" {
+  type        = "string"
+  default     = ""
+  description = "Hostname of external SMTP email server"
+}
+
+variable "mail_password" {
+  type        = "string"
+  default     = ""
+  description = "Password associated with account used to send email"
+}
+
+variable "mail_port" {
+  type        = "string"
+  default     = ""
+  description = "Port used to connect to external SMTP email server"
+}
+
+variable "mail_username" {
+  type        = "string"
+  default     = ""
+  description = "Username associated with account used to send email"
+}

--- a/apps/document-services/variables.tf
+++ b/apps/document-services/variables.tf
@@ -24,24 +24,20 @@ variable "cybersource_profile_id" {
 
 variable "mail_host" {
   type        = "string"
-  default     = ""
   description = "Hostname of external SMTP email server"
 }
 
 variable "mail_password" {
   type        = "string"
-  default     = ""
   description = "Password associated with account used to send email"
 }
 
 variable "mail_port" {
   type        = "string"
-  default     = ""
   description = "Port used to connect to external SMTP email server"
 }
 
 variable "mail_username" {
   type        = "string"
-  default     = ""
   description = "Username associated with account used to send email"
 }


### PR DESCRIPTION
This adds the variables which will allow the Doc Services application to connect to MIT's email service. The four values have been added to the appropriate place.

The PR to add support for these variables is at https://github.mit.edu/mitlibraries/docs/pull/33 .