### PR TITLE
Lower the memory/cpu for slingshot data load task

### DIFF
--- a/apps/geoweb/slingshot.tf
+++ b/apps/geoweb/slingshot.tf
@@ -145,8 +145,8 @@ resource "aws_ecs_task_definition" "slingshot" {
   execution_role_arn       = "${aws_iam_role.slingshot.arn}"
   task_role_arn            = "${aws_iam_role.slingshot_task.arn}"
   network_mode             = "awsvpc"
-  cpu                      = 2048
-  memory                   = 4096
+  cpu                      = 256
+  memory                   = 512
   tags                     = "${module.label_slingshot.tags}"
 }
 
@@ -216,8 +216,8 @@ resource "aws_iam_role_policy" "cloudwatch_run_task" {
 resource "aws_cloudwatch_event_rule" "default" {
   name                = "${module.label_slingshot.name}"
   description         = "Slingshot data load"
-  is_enabled          = false
-  schedule_expression = "cron(0 9 * * ? *)"
+  is_enabled          = true
+  schedule_expression = "cron(0 12 * * ? *)"
   tags                = "${module.label_slingshot.tags}"
 }
 

--- a/apps/geoweb/tasks/slingshot.json
+++ b/apps/geoweb/tasks/slingshot.json
@@ -14,7 +14,7 @@
       {"name": "PG_PASSWORD", "valueFrom": "${pg_password}"},
       {"name": "GEOSERVER_PASSWORD", "valueFrom": "${geoserver_password}"}
     ],
-    "memoryReservation": 4096,
+    "memoryReservation": 512,
     "command": [
       "publish",
       "--publish-all",


### PR DESCRIPTION
The issues with slingshot's memory consumption have been sorted out so
it should be able to load layers of any size and keep memory usage at a
constant level.