### PR TITLE
Upgrade AWS provider

### DIFF
--- a/apps/DIP/main.tf
+++ b/apps/DIP/main.tf
@@ -15,7 +15,7 @@
  * The Elasticsearch search index is created in the [shared module](https://github.com/MITLibraries/mitlib-terraform/tree/master/shared/elasticsearch).
  */
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/archivesspace/main.tf
+++ b/apps/archivesspace/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/author_lookup/main.tf
+++ b/apps/author_lookup/main.tf
@@ -11,7 +11,7 @@
  * The rest of the AWS resources are created/managed by zappa during deploy.
  **/
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/cantaloupe/main.tf
+++ b/apps/cantaloupe/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/carbon/main.tf
+++ b/apps/carbon/main.tf
@@ -5,7 +5,7 @@
  **/
 
 provider "aws" {
-  version = "~> 2.6.0"
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/cloudcheckr/main.tf
+++ b/apps/cloudcheckr/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/document-services/main.tf
+++ b/apps/document-services/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/dome/main.tf
+++ b/apps/dome/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.7.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/dpworkshop/main.tf
+++ b/apps/dpworkshop/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/ebooks/main.tf
+++ b/apps/ebooks/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/ezproxy-lookup/main.tf
+++ b/apps/ezproxy-lookup/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0"
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/futureoflibraries/main.tf
+++ b/apps/futureoflibraries/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/geoweb/main.tf
+++ b/apps/geoweb/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.19.0"
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/grandchallenges/main.tf
+++ b/apps/grandchallenges/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/haydenreno/main.tf
+++ b/apps/haydenreno/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/lib-digitalobjects/main.tf
+++ b/apps/lib-digitalobjects/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/libraries-website/main.tf
+++ b/apps/libraries-website/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.7.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/libstaff/main.tf
+++ b/apps/libstaff/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/oatf/main.tf
+++ b/apps/oatf/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/similewidgets/main.tf
+++ b/apps/similewidgets/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/tarot/main.tf
+++ b/apps/tarot/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0"
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/apps/tdr/main.tf
+++ b/apps/tdr/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/global/main.tf
+++ b/global/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/shared/bastion/main.tf
+++ b/shared/bastion/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0"
+  version = "~> 2.0"
   region  = "${var.aws_region}"
 }
 

--- a/shared/deploy/main.tf
+++ b/shared/deploy/main.tf
@@ -5,7 +5,7 @@
  *
  **/
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/shared/elasticsearch/main.tf
+++ b/shared/elasticsearch/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 

--- a/shared/network/main.tf
+++ b/shared/network/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.6.0 "
+  version = "~> 2.0"
   region  = "us-east-1"
 }
 


### PR DESCRIPTION
Closes #146. This is an initial step to upgrading Terraform to 0.12.
I've switched the semver to track the major version. They seem to do a
good job with not introducing breaking changes on minor version upgrades
and there are already multiple checks in place that should unearth any
problems before doing a production deploy.