### PR TITLE
Pin all our local modules to the 0.11 tag

### DIFF
--- a/apps/DIP/dip.tf
+++ b/apps/DIP/dip.tf
@@ -3,12 +3,12 @@
 ########################
 
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "dip-aleph-S3"
 }
 
 module "alephs3" {
-  source                 = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source                 = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name                   = "dip-aleph-S3"
   expire_objects_enabled = "true"
   expiration_days        = "60"
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "read" {
 }
 
 module "es-label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "dip-es-indexes"
 }
 
@@ -62,7 +62,7 @@ resource "aws_iam_policy" "es_read" {
 
 # Create API Credentials for Timdex (Heroku App) to read from Aleph index
 module "timdex-es-label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "timdex-es"
 }
 
@@ -125,12 +125,12 @@ resource "aws_elasticsearch_domain_policy" "default" {
 ###################
 
 module "mario-label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "mario"
 }
 
 module "ecr" {
-  source = "git::https://github.com/mitlibraries/tf-mod-ecr?ref=master"
+  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.11"
   name   = "mario"
 }
 

--- a/apps/DIP/main.tf
+++ b/apps/DIP/main.tf
@@ -33,5 +33,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/archivesspace/main.tf
+++ b/apps/archivesspace/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/author_lookup/author_lookup.tf
+++ b/apps/author_lookup/author_lookup.tf
@@ -1,15 +1,15 @@
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "author-lookup"
 }
 
 module "bucket" {
-  source = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name   = "author-lookup"
 }
 
 module "secret" {
-  source = "git::https://github.com/mitlibraries/tf-mod-secrets?ref=master"
+  source = "github.com/mitlibraries/tf-mod-secrets?ref=0.11"
   name   = "author-lookup"
 }
 

--- a/apps/author_lookup/main.tf
+++ b/apps/author_lookup/main.tf
@@ -28,5 +28,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/cantaloupe/cantaloupe.tf
+++ b/apps/cantaloupe/cantaloupe.tf
@@ -1,11 +1,11 @@
 module "label" {
-  source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "cantaloupe"
 }
 
 # Create ECR repository
 module "ecr" {
-  source = "git::https://github.com/MITLibraries/tf-mod-ecr?ref=master"
+  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.11"
   name   = "cantaloupe"
 }
 
@@ -39,7 +39,7 @@ resource "aws_route53_record" "dns" {
 
 # Create target group and ALB ingress rule for our container
 module "alb_ingress" {
-  source              = "git::https://github.com/MITLibraries/tf-mod-alb-ingress?ref=master"
+  source              = "github.com/mitlibraries/tf-mod-alb-ingress?ref=0.11"
   name                = "cantaloupe"
   vpc_id              = "${module.shared.vpc_id}"
   listener_arns       = ["${lookup(local.shared_alb_listeners, local.env)}"]
@@ -63,7 +63,7 @@ resource "aws_ecs_cluster" "ecs_cluster" {
 
 # Create ECS Fargate Service
 module "fargate" {
-  source                    = "git::https://github.com/MITLibraries/tf-mod-alb-ecs-service-task?ref=master"
+  source                    = "github.com/mitlibraries/tf-mod-alb-ecs-service-task?ref=0.11"
   name                      = "cantaloupe"
   container_name            = "${module.label.name}"
   ecs_cluster_arn           = "${aws_ecs_cluster.ecs_cluster.arn}"

--- a/apps/cantaloupe/main.tf
+++ b/apps/cantaloupe/main.tf
@@ -18,5 +18,5 @@ terraform {
 
 #Get shared Resources
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/cantaloupe/s3.tf
+++ b/apps/cantaloupe/s3.tf
@@ -1,6 +1,6 @@
 # Create S3 Bucket for storing images and create IAM user
 module "s3store" {
-  source = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name   = "cantaloupe-storage"
 }
 
@@ -22,7 +22,7 @@ resource "aws_iam_access_key" "s3store" {
 
 # Create S3 Bucket for storing images and create IAM user
 module "s3cache" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name               = "cantaloupe-cache"
   versioning_enabled = "false"
 

--- a/apps/carbon/carbon.tf
+++ b/apps/carbon/carbon.tf
@@ -6,17 +6,17 @@ locals = {
 }
 
 module "secret" {
-  source = "git::https://github.com/mitlibraries/tf-mod-secrets?ref=master"
+  source = "github.com/mitlibraries/tf-mod-secrets?ref=0.11"
   name   = "carbon"
 }
 
 module "ecr" {
-  source = "git::https://github.com/mitlibraries/tf-mod-ecr?ref=master"
+  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.11"
   name   = "carbon"
 }
 
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "carbon"
 }
 

--- a/apps/carbon/main.tf
+++ b/apps/carbon/main.tf
@@ -30,5 +30,5 @@ data "aws_vpc" "mit_net_vpc" {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/document-services/document-services.tf
+++ b/apps/document-services/document-services.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "document-services"
 }
 
@@ -28,7 +28,7 @@ resource "aws_security_group" "default" {
 # Create an S3 Bucket to store MIT cert and key, and attach to beanstalk instance profile for access
 
 module "s3_cert_store" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name               = "document-services-certstore"
   versioning_enabled = "false"
 }
@@ -39,7 +39,7 @@ resource "aws_iam_role_policy_attachment" "default_ro" {
 }
 
 module "rds_docsvcs" {
-  source                      = "git::https://github.com/mitlibraries/tf-mod-rds?ref=master"
+  source                      = "github.com/mitlibraries/tf-mod-rds?ref=0.11"
   engine                      = "mysql"
   engine_version              = "5.5.61"
   instance_class              = "db.t3.micro"
@@ -62,7 +62,7 @@ module "rds_docsvcs" {
 }
 
 module "eb_docsvcs" {
-  source = "git::https://github.com/mitlibraries/tf-mod-elasticbeanstalk-env?ref=master"
+  source = "github.com/mitlibraries/tf-mod-elasticbeanstalk-env?ref=0.11"
 
   app     = "${module.shared.docsvcs_app_name}"
   keypair = "mit-mjbernha"

--- a/apps/document-services/main.tf
+++ b/apps/document-services/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/dome/dome.tf
+++ b/apps/dome/dome.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "dome"
 }
 

--- a/apps/dome/main.tf
+++ b/apps/dome/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/dome/rds.tf
+++ b/apps/dome/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-rds?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-rds?ref=0.11"
   engine             = "postgres"
   engine_version     = "11.4"
   instance_class     = "db.t2.micro"

--- a/apps/ebooks/ebooks.tf
+++ b/apps/ebooks/ebooks.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "ebooks"
 }
 
@@ -11,7 +11,7 @@ resource "aws_iam_user" "default" {
 }
 
 module "ebooks" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name               = "ebooks"
   versioning_enabled = "true"
 }

--- a/apps/ebooks/main.tf
+++ b/apps/ebooks/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/ezproxy-lookup/ezproxy_s3.tf
+++ b/apps/ezproxy-lookup/ezproxy_s3.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "ezproxy-lookup"
 }
 
@@ -11,7 +11,7 @@ resource "aws_iam_user" "default" {
 }
 
 module "ezproxy-lookup" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name               = "ezproxy-lookup"
   versioning_enabled = "true"
 }

--- a/apps/ezproxy-lookup/main.tf
+++ b/apps/ezproxy-lookup/main.tf
@@ -16,5 +16,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/futureoflibraries/main.tf
+++ b/apps/futureoflibraries/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/geoweb/geoblacklight.tf
+++ b/apps/geoweb/geoblacklight.tf
@@ -1,10 +1,10 @@
 module "label_geoblacklight" {
-  source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "geoblacklight"
 }
 
 module "geoblacklight_ecr" {
-  source = "git::https://github.com/MITLibraries/tf-mod-ecr?ref=master"
+  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.11"
   name   = "geoblacklight"
 }
 

--- a/apps/geoweb/geoweb.tf
+++ b/apps/geoweb/geoweb.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 module "label" {
-  source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "geoweb"
 }
 

--- a/apps/geoweb/main.tf
+++ b/apps/geoweb/main.tf
@@ -16,5 +16,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/geoweb/modules/ec2/main.tf
+++ b/apps/geoweb/modules/ec2/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "${var.name}"
 }
 

--- a/apps/geoweb/rds.tf
+++ b/apps/geoweb/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                  = "git::https://github.com/mitlibraries/tf-mod-rds?ref=master"
+  source                  = "github.com/mitlibraries/tf-mod-rds?ref=0.11"
   engine                  = "postgres"
   engine_version          = "11.1"
   instance_class          = "${var.postgres_instance_type}"

--- a/apps/geoweb/s3upload.tf
+++ b/apps/geoweb/s3upload.tf
@@ -1,11 +1,11 @@
 module "geoweb_upload" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name               = "geoweb-upload"
   versioning_enabled = "true"
 }
 
 module "geoweb_label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "geoweb-upload"
 }
 

--- a/apps/geoweb/slingshot.tf
+++ b/apps/geoweb/slingshot.tf
@@ -1,10 +1,10 @@
 module "label_slingshot" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "slingshot"
 }
 
 module "slingshot_ecr" {
-  source = "git::https://github.com/mitlibraries/tf-mod-ecr?ref=master"
+  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.11"
   name   = "slingshot"
 }
 

--- a/apps/grandchallenges/grandchallenges.tf
+++ b/apps/grandchallenges/grandchallenges.tf
@@ -2,7 +2,7 @@
 #We will investigate options for generating SSL certificates in the future
 
 module "grand_web" {
-  source               = "git::https://github.com/mitlibraries/tf-mod-cdn-s3?ref=master"
+  source               = "github.com/mitlibraries/tf-mod-cdn-s3?ref=0.11"
   name                 = "grandchallenges"
   aliases              = ["grandchallenges.mitlib.net"]
   ext_aliases          = ["grandchallenges.mit.edu"]

--- a/apps/haydenreno/main.tf
+++ b/apps/haydenreno/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/lib-digitalobjects/lib-digitalobjects.tf
+++ b/apps/lib-digitalobjects/lib-digitalobjects.tf
@@ -1,12 +1,12 @@
 # The SSL certificate was created manually (via MIT) and imported manually
 # We will investigate options for generating SSL certificates in the future
 module "label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "lib-digitalobjects"
 }
 
 module "lib-digitalobjects" {
-  source = "git::https://github.com/mitlibraries/tf-mod-cdn-s3?ref=master"
+  source = "github.com/mitlibraries/tf-mod-cdn-s3?ref=0.11"
   name   = "lib-digitalobjects"
 
   aliases = ["lib-digitalobjects-${terraform.workspace}.mitlib.net"]

--- a/apps/lib-digitalobjects/main.tf
+++ b/apps/lib-digitalobjects/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/libraries-website/libraries-website.tf
+++ b/apps/libraries-website/libraries-website.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "git::https://github.com/MITLibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "libraries-website"
 }
 
@@ -44,7 +44,7 @@ resource "aws_security_group" "default" {
 }
 
 module "db" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-rds?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-rds?ref=0.11"
   engine             = "mariadb"
   engine_version     = "10.3.8"
   instance_class     = "db.t2.micro"

--- a/apps/libraries-website/main.tf
+++ b/apps/libraries-website/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/libstaff/libstaff.tf
+++ b/apps/libstaff/libstaff.tf
@@ -1,5 +1,5 @@
 module "website" {
-  source         = "git::https://github.com/mitlibraries/tf-mod-s3-website?ref=master"
+  source         = "github.com/mitlibraries/tf-mod-s3-website?ref=0.11"
   name           = "libstaff-archive"
   hostname       = "libstaff-archive.mitlib.net"
   parent_zone_id = "${module.shared.public_zoneid}"

--- a/apps/libstaff/main.tf
+++ b/apps/libstaff/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/oatf/main.tf
+++ b/apps/oatf/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/tarot/main.tf
+++ b/apps/tarot/main.tf
@@ -16,5 +16,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/apps/tarot/s3upload.tf
+++ b/apps/tarot/s3upload.tf
@@ -1,11 +1,11 @@
 module "tarot_upload" {
-  source             = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name               = "tarot-upload"
   versioning_enabled = "true"
 }
 
 module "tarot_label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "tarot-label"
 }
 

--- a/apps/tdr/main.tf
+++ b/apps/tdr/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/global/mitlibcert.tf
+++ b/global/mitlibcert.tf
@@ -1,5 +1,5 @@
 module "acm_request_certificate" {
-  source                            = "git::https://github.com/mitlibraries/tf-mod-acm-cert?ref=master"
+  source                            = "github.com/mitlibraries/tf-mod-acm-cert?ref=0.11"
   domain_name                       = "mitlib.net"
   ttl                               = "300"
   subject_alternative_names         = ["*.mitlib.net"]

--- a/global/r53.tf
+++ b/global/r53.tf
@@ -5,7 +5,7 @@ resource "aws_route53_zone" "main_pub" {
 }
 
 module "prodvpc" {
-  source    = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source    = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
   workspace = "prod"
 }
 
@@ -25,7 +25,7 @@ resource "aws_route53_zone" "main_priv" {
 
 #Associate Stage VPC with Internal DNS
 module "stagevpc" {
-  source    = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source    = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
   workspace = "stage"
 }
 

--- a/shared/bastion/bastion.tf
+++ b/shared/bastion/bastion.tf
@@ -44,11 +44,11 @@ resource "aws_s3_bucket_object" "ssh_public_keys" {
 }
 
 module "latest_ami" {
-  source = "git::https://github.com/mitlibraries/tf-mod-latest-ami?ref=master"
+  source = "github.com/mitlibraries/tf-mod-latest-ami?ref=0.11"
 }
 
 module "bastion" {
-  source                    = "git::https://github.com/mitlibraries/tf-mod-bastion-host?ref=master"
+  source                    = "github.com/mitlibraries/tf-mod-bastion-host?ref=0.11"
   name                      = "bastion"
   instance_type             = "t3.nano"
   ami                       = "${module.latest_ami.ec2_linux_ami_id}"

--- a/shared/bastion/main.tf
+++ b/shared/bastion/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }

--- a/shared/deploy/deploy.tf
+++ b/shared/deploy/deploy.tf
@@ -1,4 +1,4 @@
 module "bucket" {
-  source = "git::https://github.com/mitlibraries/tf-mod-s3-iam?ref=master"
+  source = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
   name   = "deploy-mitlib"
 }

--- a/shared/elasticsearch/elasticsearch.tf
+++ b/shared/elasticsearch/elasticsearch.tf
@@ -1,5 +1,5 @@
 module "elasticsearch" {
-  source = "git::https://github.com/mitlibraries/tf-mod-aws-elasticsearch?ref=master"
+  source = "github.com/mitlibraries/tf-mod-aws-elasticsearch?ref=0.11"
   name   = "elasticsearch"
 
   instance_count                     = "${var.instance_count}"

--- a/shared/network/alb.tf
+++ b/shared/network/alb.tf
@@ -3,7 +3,7 @@
 ######################
 #Creates default restricted (18.0.0.0/9) ALB that uses *.mitlib.net cert by default
 module "alb_restricted" {
-  source                    = "git::https://github.com/mitlibraries/tf-mod-alb?ref=master"
+  source                    = "github.com/mitlibraries/tf-mod-alb?ref=0.11"
   name                      = "alb-restricted"
   http_ingress_cidr_blocks  = ["${var.alb_cidrs}"]
   https_ingress_cidr_blocks = ["${var.alb_cidrs}"]
@@ -17,7 +17,7 @@ module "alb_restricted" {
 }
 
 module "sg_label" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "alb-restricted"
 }
 
@@ -48,7 +48,7 @@ module "all_access_from_alb" {
 #########################
 #Creates default public ALB that uses *.mitlib.net cert by default
 module "alb_public" {
-  source              = "git::https://github.com/mitlibraries/tf-mod-alb?ref=master"
+  source              = "github.com/mitlibraries/tf-mod-alb?ref=0.11"
   name                = "alb-public"
   vpc_id              = "${module.vpc.vpc_id}"
   ip_address_type     = "ipv4"
@@ -60,7 +60,7 @@ module "alb_public" {
 }
 
 module "sg_label_public" {
-  source = "git::https://github.com/mitlibraries/tf-mod-name?ref=master"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
   name   = "alb-public"
 }
 

--- a/shared/network/main.tf
+++ b/shared/network/main.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "git::https://github.com/mitlibraries/tf-mod-shared-provider?ref=master"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
 }


### PR DESCRIPTION
I have already gone through and tagged all our modules at the current
HEAD with 0.11. This should be consistent with the expected state. This
commit pins all the references to these modules to the 0.11 tag. All
this is in preparation for upgrading our modules to 0.12.