### PR TITLE
Re-enabled Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-#env:
-#  - TF_VERSION=0.11.10
-#before_install:
-#  - wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -O /tmp/tf.zip
-#  - unzip -d bin/ /tmp/tf.zip
-#  - export PATH=$PATH:$PWD/bin
-#  - terraform -v
-#script:
-#  - make all
+env:
+  - TF_VERSION=0.12.9
+before_install:
+  - wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -O /tmp/tf.zip
+  - unzip -d bin/ /tmp/tf.zip
+  - export PATH=$PATH:$PWD/bin
+  - terraform -v
+script:
+  - make -j all


### PR DESCRIPTION
This fixes the Makefile to work with 0.12. I've added a grep condition
to test for the config being upgraded to version 0.12, so the build
target will only be run on 0.12 configs.

make will take longer to run now since terraform init has to be called
on each config. I'd suggest running make with the -j option. This will
run the build target on each config in parallel.