### PR TITLE
Upgrade DIP and elasticsearch to 0.12

### DIFF
--- a/apps/DIP/dip.tf
+++ b/apps/DIP/dip.tf
@@ -3,12 +3,12 @@
 ########################
 
 module "label" {
-  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
   name   = "dip-aleph-S3"
 }
 
 module "alephs3" {
-  source                 = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
+  source                 = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.12"
   name                   = "dip-aleph-S3"
   expire_objects_enabled = "true"
   expiration_days        = "60"
@@ -19,17 +19,17 @@ resource "aws_iam_user" "default" {
   name          = "${module.label.name}-readwrite"
   path          = "/"
   force_destroy = "false"
-  tags          = "${module.label.tags}"
+  tags          = module.label.tags
 }
 
 resource "aws_iam_user_policy_attachment" "default_rw" {
-  user       = "${aws_iam_user.default.name}"
-  policy_arn = "${module.alephs3.readwrite_arn}"
+  user       = aws_iam_user.default.name
+  policy_arn = module.alephs3.readwrite_arn
 }
 
 # Generate API credentials
 resource "aws_iam_access_key" "default" {
-  user = "${aws_iam_user.default.name}"
+  user = aws_iam_user.default.name
 }
 
 ################################
@@ -50,19 +50,19 @@ data "aws_iam_policy_document" "read" {
 }
 
 module "es-label" {
-  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
   name   = "dip-es-indexes"
 }
 
 resource "aws_iam_policy" "es_read" {
   name        = "${module.es-label.name}-read"
   description = "Policy to allow IAM user read only access to DIP ES indexes"
-  policy      = "${data.aws_iam_policy_document.read.json}"
+  policy      = data.aws_iam_policy_document.read.json
 }
 
 # Create API Credentials for Timdex (Heroku App) to read from Aleph index
 module "timdex-es-label" {
-  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
   name   = "timdex-es"
 }
 
@@ -70,17 +70,17 @@ resource "aws_iam_user" "timdex" {
   name          = "${module.timdex-es-label.name}-read"
   path          = "/"
   force_destroy = "false"
-  tags          = "${module.timdex-es-label.tags}"
+  tags          = module.timdex-es-label.tags
 }
 
 resource "aws_iam_user_policy_attachment" "timdex_es_ro" {
-  user       = "${aws_iam_user.timdex.name}"
-  policy_arn = "${aws_iam_policy.es_read.arn}"
+  user       = aws_iam_user.timdex.name
+  policy_arn = aws_iam_policy.es_read.arn
 }
 
 # Generate API credentials
 resource "aws_iam_access_key" "timdex" {
-  user = "${aws_iam_user.timdex.name}"
+  user = aws_iam_user.timdex.name
 }
 
 ##############################
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "default" {
     actions = ["es:*"]
 
     resources = [
-      "${module.shared.es_arn}",
+      module.shared.es_arn,
       "${module.shared.es_arn}/*",
     ]
 
@@ -110,14 +110,14 @@ data "aws_iam_policy_document" "default" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
-      values = ["${module.shared.nat_public_ips}"]
+      values = module.shared.nat_public_ips
     }
   }
 }
 
 resource "aws_elasticsearch_domain_policy" "default" {
-  domain_name     = "${module.shared.es_domain_name}"
-  access_policies = "${data.aws_iam_policy_document.default.json}"
+  domain_name     = module.shared.es_domain_name
+  access_policies = data.aws_iam_policy_document.default.json
 }
 
 ###################
@@ -125,12 +125,12 @@ resource "aws_elasticsearch_domain_policy" "default" {
 ###################
 
 module "mario-label" {
-  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
   name   = "mario"
 }
 
 module "ecr" {
-  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-ecr?ref=0.12"
   name   = "mario"
 }
 
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "mario_task_assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
@@ -149,7 +149,7 @@ data "aws_iam_policy_document" "mario_lambda_assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type = "Service"
 
       identifiers = [
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "mario_lambda_s3" {
     ]
 
     resources = [
-      "${aws_s3_bucket.lambda_s3.arn}",
+      aws_s3_bucket.lambda_s3.arn,
       "${aws_s3_bucket.lambda_s3.arn}/*",
     ]
   }
@@ -186,7 +186,7 @@ data "aws_iam_policy_document" "mario_lambda_func" {
     ]
 
     resources = [
-      "${aws_lambda_function.default.arn}",
+      aws_lambda_function.default.arn,
     ]
   }
 }
@@ -194,47 +194,47 @@ data "aws_iam_policy_document" "mario_lambda_func" {
 resource "aws_iam_policy" "mario_lambda_s3_policy" {
   name        = "${module.mario-label.name}-lambda-s3"
   description = "Policy to allow deploy user to write to mario lambda s3"
-  policy      = "${data.aws_iam_policy_document.mario_lambda_s3.json}"
+  policy      = data.aws_iam_policy_document.mario_lambda_s3.json
 }
 
 resource "aws_iam_policy" "mario_lambda_func_policy" {
   name        = "${module.mario-label.name}-lambda-func"
   description = "Policy to allow deploy user to update function code"
-  policy      = "${data.aws_iam_policy_document.mario_lambda_func.json}"
+  policy      = data.aws_iam_policy_document.mario_lambda_func.json
 }
 
 resource "aws_iam_user" "mario_deploy" {
   name = "${module.mario-label.name}-deploy"
-  tags = "${module.mario-label.tags}"
+  tags = module.mario-label.tags
 }
 
 resource "aws_iam_user_policy_attachment" "mario_lambda_s3_attach" {
-  user       = "${aws_iam_user.mario_deploy.name}"
-  policy_arn = "${aws_iam_policy.mario_lambda_s3_policy.arn}"
+  user       = aws_iam_user.mario_deploy.name
+  policy_arn = aws_iam_policy.mario_lambda_s3_policy.arn
 }
 
 resource "aws_iam_user_policy_attachment" "mario_lambda_func_attach" {
-  user       = "${aws_iam_user.mario_deploy.name}"
-  policy_arn = "${aws_iam_policy.mario_lambda_func_policy.arn}"
+  user       = aws_iam_user.mario_deploy.name
+  policy_arn = aws_iam_policy.mario_lambda_func_policy.arn
 }
 
 resource "aws_iam_user_policy_attachment" "mario_ecr_login_attach" {
-  user       = "${aws_iam_user.mario_deploy.name}"
-  policy_arn = "${module.ecr.policy_login_arn}"
+  user       = aws_iam_user.mario_deploy.name
+  policy_arn = module.ecr.policy_login_arn
 }
 
 resource "aws_iam_user_policy_attachment" "mario_ecr_read_attach" {
-  user       = "${aws_iam_user.mario_deploy.name}"
-  policy_arn = "${module.ecr.policy_read_arn}"
+  user       = aws_iam_user.mario_deploy.name
+  policy_arn = module.ecr.policy_read_arn
 }
 
 resource "aws_iam_user_policy_attachment" "mario_ecr_write_attach" {
-  user       = "${aws_iam_user.mario_deploy.name}"
-  policy_arn = "${module.ecr.policy_write_arn}"
+  user       = aws_iam_user.mario_deploy.name
+  policy_arn = module.ecr.policy_write_arn
 }
 
 resource "aws_iam_access_key" "mario_deploy" {
-  user = "${aws_iam_user.mario_deploy.name}"
+  user = aws_iam_user.mario_deploy.name
 }
 
 ###################
@@ -266,31 +266,31 @@ data "aws_iam_policy_document" "mario_cloudwatch_policy" {
 
 resource "aws_iam_role" "mario_execution_role" {
   name               = "${module.mario-label.name}-lambda"
-  assume_role_policy = "${data.aws_iam_policy_document.mario_lambda_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.mario_lambda_assume_role.json
   description        = "Role used by Lambda for running mario container"
-  tags               = "${module.mario-label.tags}"
+  tags               = module.mario-label.tags
 }
 
 resource "aws_iam_role_policy" "runtask_attach" {
   name   = "${module.mario-label.name}-runtask"
-  role   = "${aws_iam_role.mario_execution_role.name}"
-  policy = "${data.aws_iam_policy_document.runtask_policy.json}"
+  role   = aws_iam_role.mario_execution_role.name
+  policy = data.aws_iam_policy_document.runtask_policy.json
 }
 
 resource "aws_iam_role_policy" "mario_cloudwatch_attach" {
   name   = "${module.mario-label.name}-cloudwatch"
-  role   = "${aws_iam_role.mario_execution_role.name}"
-  policy = "${data.aws_iam_policy_document.mario_cloudwatch_policy.json}"
+  role   = aws_iam_role.mario_execution_role.name
+  policy = data.aws_iam_policy_document.mario_cloudwatch_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "mario_ecr_login_attach" {
-  role       = "${aws_iam_role.mario_execution_role.name}"
-  policy_arn = "${module.ecr.policy_login_arn}"
+  role       = aws_iam_role.mario_execution_role.name
+  policy_arn = module.ecr.policy_login_arn
 }
 
 resource "aws_iam_role_policy_attachment" "mario_ecr_read_attach" {
-  role       = "${aws_iam_role.mario_execution_role.name}"
-  policy_arn = "${module.ecr.policy_read_arn}"
+  role       = aws_iam_role.mario_execution_role.name
+  policy_arn = module.ecr.policy_read_arn
 }
 
 #########################
@@ -299,24 +299,24 @@ resource "aws_iam_role_policy_attachment" "mario_ecr_read_attach" {
 
 resource "aws_iam_role" "mario_task_role" {
   name               = "${module.mario-label.name}-task"
-  assume_role_policy = "${data.aws_iam_policy_document.mario_task_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.mario_task_assume_role.json
   description        = "Role used by mario Fargate task"
-  tags               = "${module.mario-label.tags}"
+  tags               = module.mario-label.tags
 }
 
 resource "aws_iam_role_policy_attachment" "es_read_attach" {
-  role       = "${aws_iam_role.mario_task_role.name}"
-  policy_arn = "${module.shared.es_read_policy_arn}"
+  role       = aws_iam_role.mario_task_role.name
+  policy_arn = module.shared.es_read_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "es_write_attach" {
-  role       = "${aws_iam_role.mario_task_role.name}"
-  policy_arn = "${module.shared.es_write_policy_arn}"
+  role       = aws_iam_role.mario_task_role.name
+  policy_arn = module.shared.es_write_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "s3_read_attach" {
-  role       = "${aws_iam_role.mario_task_role.name}"
-  policy_arn = "${module.alephs3.readonly_arn}"
+  role       = aws_iam_role.mario_task_role.name
+  policy_arn = module.alephs3.readonly_arn
 }
 
 ######################
@@ -325,21 +325,21 @@ resource "aws_iam_role_policy_attachment" "s3_read_attach" {
 
 resource "aws_s3_bucket" "lambda_s3" {
   bucket = "${module.mario-label.name}-lambda"
-  tags   = "${module.mario-label.tags}"
+  tags   = module.mario-label.tags
 }
 
 resource "aws_lambda_permission" "run_lambda" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.default.arn}"
+  function_name = aws_lambda_function.default.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${module.alephs3.bucket_arn}"
+  source_arn    = module.alephs3.bucket_arn
 }
 
 resource "aws_s3_bucket_notification" "default" {
-  bucket = "${module.alephs3.bucket_id}"
+  bucket = module.alephs3.bucket_id
 
   lambda_function {
-    lambda_function_arn = "${aws_lambda_function.default.arn}"
+    lambda_function_arn = aws_lambda_function.default.arn
     events              = ["s3:ObjectCreated:*"]
   }
 }
@@ -351,9 +351,9 @@ resource "aws_s3_bucket_notification" "default" {
 resource "aws_security_group" "default" {
   name        = "${module.mario-label.name}-sg"
   description = "Allow all outband traffic"
-  vpc_id      = "${module.shared.vpc_id}"
+  vpc_id      = module.shared.vpc_id
 
-  tags = "${module.mario-label.tags}"
+  tags = module.mario-label.tags
 
   egress {
     from_port   = 0
@@ -370,19 +370,19 @@ resource "aws_cloudwatch_log_group" "lambda" {
 
 resource "aws_lambda_function" "default" {
   function_name = "${module.mario-label.name}-lambda"
-  s3_bucket     = "${aws_s3_bucket.lambda_s3.id}"
+  s3_bucket     = aws_s3_bucket.lambda_s3.id
   s3_key        = "mario.zip"
   handler       = "mario-powerup"
-  role          = "${aws_iam_role.mario_execution_role.arn}"
+  role          = aws_iam_role.mario_execution_role.arn
   description   = "Lambda that starts mario fargate task"
   runtime       = "go1.x"
 
   environment {
     variables = {
-      "ECS_SECURITY_GROUP" = "${aws_security_group.default.id}"
-      "ECS_SUBNETS"        = "${join(",", module.shared.private_subnets)}"
-      "ECS_CLUSTER"        = "${aws_ecs_cluster.default.arn}"
-      "ECS_FAMILY"         = "${aws_ecs_task_definition.default.family}"
+      "ECS_SECURITY_GROUP" = aws_security_group.default.id
+      "ECS_SUBNETS"        = join(",", module.shared.private_subnets)
+      "ECS_CLUSTER"        = aws_ecs_cluster.default.arn
+      "ECS_FAMILY"         = aws_ecs_task_definition.default.family
       "ES_URL"             = "https://${module.shared.es_endpoint}"
     }
   }
@@ -394,7 +394,7 @@ resource "aws_lambda_function" "default" {
 
 resource "aws_ecs_cluster" "default" {
   name = "${module.mario-label.name}-cluster"
-  tags = "${module.mario-label.tags}"
+  tags = module.mario-label.tags
 }
 
 resource "aws_cloudwatch_log_group" "mario" {
@@ -403,21 +403,22 @@ resource "aws_cloudwatch_log_group" "mario" {
 }
 
 data "template_file" "mario_task_template" {
-  template = "${file("${path.module}/task.json")}"
+  template = file("${path.module}/task.json")
 
   vars = {
-    image     = "${module.ecr.registry_url}"
-    log_group = "${aws_cloudwatch_log_group.mario.name}"
+    image     = module.ecr.registry_url
+    log_group = aws_cloudwatch_log_group.mario.name
   }
 }
 
 resource "aws_ecs_task_definition" "default" {
-  family                   = "${module.mario-label.name}"
-  container_definitions    = "${data.template_file.mario_task_template.rendered}"
+  family                   = module.mario-label.name
+  container_definitions    = data.template_file.mario_task_template.rendered
   requires_compatibilities = ["FARGATE"]
-  task_role_arn            = "${aws_iam_role.mario_task_role.arn}"
-  execution_role_arn       = "${aws_iam_role.mario_execution_role.arn}"
+  task_role_arn            = aws_iam_role.mario_task_role.arn
+  execution_role_arn       = aws_iam_role.mario_execution_role.arn
   network_mode             = "awsvpc"
   cpu                      = 256
   memory                   = 512
 }
+

--- a/apps/DIP/main.tf
+++ b/apps/DIP/main.tf
@@ -21,8 +21,6 @@ provider "aws" {
 
 #Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
-
   backend "s3" {
     region         = "us-east-1"
     bucket         = "mit-tfstates-state"
@@ -33,5 +31,6 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }
+

--- a/apps/DIP/outputs.tf
+++ b/apps/DIP/outputs.tf
@@ -1,33 +1,34 @@
 output "access_key_id" {
-  value       = "${aws_iam_access_key.default.id}"
+  value       = aws_iam_access_key.default.id
   description = "Access key ID for the Aleph submission to S3 user"
 }
 
 output "secret_access_key" {
-  value       = "${aws_iam_access_key.default.secret}"
+  value       = aws_iam_access_key.default.secret
   sensitive   = true
   description = "Secret access key for Aleph submission to S3 user"
 }
 
 output "mario_deploy_access_key_id" {
-  value       = "${aws_iam_access_key.mario_deploy.id}"
+  value       = aws_iam_access_key.mario_deploy.id
   description = "Access key ID for the mario deploy user"
 }
 
 output "mario_deploy_secret_access_key" {
-  value       = "${aws_iam_access_key.mario_deploy.secret}"
+  value       = aws_iam_access_key.mario_deploy.secret
   sensitive   = true
   description = "Secret access key for mario deploy user."
 }
 
 output "timdex_access_key_secret" {
-  value       = "${aws_iam_access_key.timdex.secret}"
+  value       = aws_iam_access_key.timdex.secret
   sensitive   = true
   description = "Secret access key for timdex user."
 }
 
 output "timdex_access_key_id" {
-  value       = "${aws_iam_access_key.timdex.id}"
+  value       = aws_iam_access_key.timdex.id
   sensitive   = true
   description = "ID for timdex user."
 }
+

--- a/apps/DIP/versions.tf
+++ b/apps/DIP/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/shared/elasticsearch/elasticsearch.tf
+++ b/shared/elasticsearch/elasticsearch.tf
@@ -1,18 +1,19 @@
 module "elasticsearch" {
-  source = "github.com/mitlibraries/tf-mod-aws-elasticsearch?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-aws-elasticsearch?ref=0.12"
   name   = "elasticsearch"
 
-  instance_count                     = "${var.instance_count}"
-  instance_type                      = "${var.instance_type}"
-  es_zone_awareness                  = "${var.es_zone_awareness}"
-  ebs_volume_size                    = "${var.ebs_volume_size}"
-  es_version                         = "${var.es_version}"
+  instance_count                     = var.instance_count
+  instance_type                      = var.instance_type
+  es_zone_awareness                  = var.es_zone_awareness
+  ebs_volume_size                    = var.ebs_volume_size
+  es_version                         = var.es_version
   encrypt_at_rest                    = "false"
-  log_publishing_application_enabled = "${var.log_publishing_application_enabled}"
-  log_publishing_index_enabled       = "${var.log_publishing_index_enabled}"
-  log_publishing_search_enabled      = "${var.log_publishing_search_enabled}"
+  log_publishing_application_enabled = var.log_publishing_application_enabled
+  log_publishing_index_enabled       = var.log_publishing_index_enabled
+  log_publishing_search_enabled      = var.log_publishing_search_enabled
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 }
+

--- a/shared/elasticsearch/main.tf
+++ b/shared/elasticsearch/main.tf
@@ -5,8 +5,6 @@ provider "aws" {
 
 #Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
-
   backend "s3" {
     region         = "us-east-1"
     bucket         = "mit-tfstates-state"
@@ -15,3 +13,4 @@ terraform {
     encrypt        = true
   }
 }
+

--- a/shared/elasticsearch/outputs.tf
+++ b/shared/elasticsearch/outputs.tf
@@ -1,24 +1,25 @@
 output "es_arn" {
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
-  value       = "${module.elasticsearch.arn}"
+  value       = module.elasticsearch.arn
 }
 
 output "es_endpoint" {
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
-  value       = "${module.elasticsearch.endpoint}"
+  value       = module.elasticsearch.endpoint
 }
 
 output "read_policy_arn" {
   description = "Default domain read only policy ARN"
-  value       = "${module.elasticsearch.read_policy_arn}"
+  value       = module.elasticsearch.read_policy_arn
 }
 
 output "write_policy_arn" {
   description = "Default domain write policy ARN"
-  value       = "${module.elasticsearch.write_policy_arn}"
+  value       = module.elasticsearch.write_policy_arn
 }
 
 output "domain_name" {
   description = "Domain name of cluster"
-  value       = "${module.elasticsearch.domain_name}"
+  value       = module.elasticsearch.domain_name
 }
+

--- a/shared/elasticsearch/variables.tf
+++ b/shared/elasticsearch/variables.tf
@@ -29,19 +29,20 @@ variable "es_version" {
 }
 
 variable "log_publishing_index_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not"
 }
 
 variable "log_publishing_search_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not"
 }
 
 variable "log_publishing_application_enabled" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Specifies whether log publishing option for ES_APPLICATION_LOGS is enabled or not"
 }
+

--- a/shared/elasticsearch/versions.tf
+++ b/shared/elasticsearch/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This upgrades the DIP app and the shared elasticsearch resource (which
is currently only used by DIP) to 0.12. The upgrade results in no
changes being made to existing infrastructure. It's only configuration
syntax changes.