### PR TITLE
Add archivesspace DNS entry for private dns zone

### DIFF
--- a/apps/archivesspace/as.tf
+++ b/apps/archivesspace/as.tf
@@ -30,3 +30,10 @@ resource "aws_route53_record" "emmastaff" {
   records = ["as-prod-general-app4.LYRTECH.ORG"]
 }
 
+resource "aws_route53_record" "as_private" {
+  name    = "archivesspace"
+  ttl     = 3600
+  type    = "CNAME"
+  zone_id = module.shared.private_zoneid
+  records = ["as-prod-general-app4.LYRTECH.ORG"]
+}


### PR DESCRIPTION
The way our DNS has been set up, none of the records from the public
hosted zone are available from the private hosted zone. If there are
cases when something from within the VPC needs to resolve a name in a
public hosted zone record it will need to be duplicated in the private
hosted zone.