### PR TITLE
Add r/w permissions to ASpace bucket

### DIFF
--- a/apps/airflow/iam.tf
+++ b/apps/airflow/iam.tf
@@ -90,6 +90,12 @@ resource "aws_iam_role_policy" "task_role" {
   policy = data.aws_iam_policy_document.task_role.json
 }
 
+resource "aws_iam_role_policy" "airflow_aspace_rw" {
+  name   = "${module.label.name}-airflow-aspace-rw"
+  role   = aws_iam_role.airflow_task.name
+  policy = data.aws_iam_policy_document.aspace_rw.json
+}
+
 data "aws_iam_policy_document" "task_role" {
   statement {
     actions   = ["s3:*Object", "s3:*ObjectAcl"]


### PR DESCRIPTION
This adds r/w permissions to the s3 bucket being used by the OAI
harvester on the airflow worker role. It's not an ideal way to handle
this but until we can come up with a better way we'll just duplicate
whatever permissions the worker needs from the task role.