### PR TITLE
Fix location of Airflow worker task logs

### DIFF
--- a/apps/airflow/ecs.tf
+++ b/apps/airflow/ecs.tf
@@ -151,6 +151,7 @@ resource "aws_ecs_task_definition" "web" {
       "cluster"         = aws_ecs_cluster.default.name
       "es_url"          = "https://${module.shared.es_endpoint}"
       "environment"     = local.env
+      "task_logs"       = "s3://${aws_s3_bucket.logging.id}"
   })
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.airflow.arn
@@ -205,6 +206,7 @@ resource "aws_ecs_task_definition" "scheduler" {
       "cluster"         = aws_ecs_cluster.default.name
       "es_url"          = "https://${module.shared.es_endpoint}"
       "environment"     = local.env
+      "task_logs"       = "s3://${aws_s3_bucket.logging.id}"
   })
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.airflow.arn
@@ -253,6 +255,7 @@ resource "aws_ecs_task_definition" "worker" {
       "cluster"         = aws_ecs_cluster.default.name
       "es_url"          = "https://${module.shared.es_endpoint}"
       "environment"     = local.env
+      "task_logs"       = "s3://${aws_s3_bucket.logging.id}"
   })
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.airflow.arn

--- a/apps/airflow/tasks/airflow.json
+++ b/apps/airflow/tasks/airflow.json
@@ -15,7 +15,7 @@
       {"name": "AIRFLOW__CORE__LOAD_EXAMPLES", "value": "False"},
       {"name": "AIRFLOW__CORE__EXECUTOR", "value": "CeleryExecutor"},
       {"name": "AIRFLOW__CORE__REMOTE_LOGGING", "value": "True"},
-      {"name": "AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER", "value": "s3://airflow-stage-logging"},
+      {"name": "AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER", "value": "${task_logs}"},
       {"name": "AIRFLOW__CORE__ENCRYPT_S3_LOGS", "value": "False"},
       {"name": "AIRFLOW__WEBSERVER__RBAC", "value": "True"},
       {"name": "AIRFLOW__WEBSERVER__WORKERS", "value": "2"},


### PR DESCRIPTION
The S3 bucket for worker task logging was hard coded to staging. This
parameterizes it so prod logs go to the prod bucket.