### PR TITLE
Update cron schedule for data load

### DIFF
--- a/apps/geoweb/modules/ec2/main.tf
+++ b/apps/geoweb/modules/ec2/main.tf
@@ -41,6 +41,9 @@ resource "aws_instance" "default" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      "ami",
+    ]
   }
 }
 

--- a/apps/geoweb/slingshot.tf
+++ b/apps/geoweb/slingshot.tf
@@ -217,7 +217,7 @@ resource "aws_cloudwatch_event_rule" "default" {
   name                = "${module.label_slingshot.name}"
   description         = "Slingshot data load"
   is_enabled          = true
-  schedule_expression = "cron(0 12 * * ? *)"
+  schedule_expression = "cron(0 12-22/2 ? * MON-FRI *)"
   tags                = "${module.label_slingshot.tags}"
 }
 


### PR DESCRIPTION
This updates the cron schedule for the data load to happen more
frequently during normal business hours. It also prevents a complete
redeploy of solr/geoserver when the upstream AMI changes.