### PR TITLE
docs/cleanup

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -1,0 +1,36 @@
+# Global AWS Infrastructure
+
+This folder contains global scope AWS resources needed for MIT Libraries architecture. This includes resources that span both stage and prod VPCs. The resources should be deployed in the "global" Terraform workspace.
+
+### What's created?:
+* ACM cert CNAME for mitlib.net zone validation
+* Docsvcs EBS application
+* IAM users
+* Initial tfstate locking DB
+* Route53 mitlib.net zone
+* SAML integration resources
+
+### Additional Info:
+* The IAM code will need to be modified if we begin making use of IAM groups for access controls rather than policies.
+* The MIT-IdP-metadata.xml file for SAML integration should be updated from time to time.
+
+## Input Variables
+
+| Name | Description |
+|------|-------------|
+| admins | IAM user accounts to add to the administrators IAM group |
+| users | IAM user accounts to be created |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| public_zoneid | Route53 Public Zone ID |
+| public_zonename | Route53 Public Zone name |
+| private_zoneid | Route53 Private Zone ID |
+| private_zonename | Route53 Private Zone name |
+| mitlib_cert | mitlib.net wildcard certificate |
+| mit_saml_arn | MIT Identity provider arn (SAML Federated login) |
+| docsvcs_beanstalk_name | Name of Docsvcs Elastic Beanstalk application |
+| admin_accounts | Names of the administrator accounts |
+| user_account_arns | ARNs of the user accounts |

--- a/global/beanstalkapps.tf
+++ b/global/beanstalkapps.tf
@@ -2,4 +2,3 @@ resource "aws_elastic_beanstalk_application" "docsvcs" {
   name        = "mitlib-docsvcs"
   description = "CakePHP application that runs the ecommerce activities of Document Services"
 }
-

--- a/global/iam.tf
+++ b/global/iam.tf
@@ -1,13 +1,18 @@
-# Osman Din - Engineer
-resource "aws_iam_user" "osmandin" {
-  name          = "osmandin"
-  path          = "/"
-  force_destroy = "true"
+# Create IAM user accounts
+resource "aws_iam_user" "users" {
+  count = length(var.users)
+  name  = element(var.users, count.index)
+
+  # Do not delete the account if the user has created non-terraform managed
+  # access keys that may be in use.
+  force_destroy = false
 }
 
-# Eric Hanson - Engineer
-resource "aws_iam_user" "ehanson" {
-  name          = "ehanson"
-  path          = "/"
-  force_destroy = "true"
+# Give the IAM accounts listed in the "admins" variable list membership in
+# the adminstrators group.
+resource "aws_iam_group_membership" "admins" {
+  name = "Infrastructure Administrators"
+
+  users = var.admins
+  group = "Administrators"
 }

--- a/global/main.tf
+++ b/global/main.tf
@@ -29,4 +29,3 @@ terraform {
     encrypt        = true
   }
 }
-

--- a/global/mitlibcert.tf
+++ b/global/mitlibcert.tf
@@ -11,4 +11,3 @@ module "acm_request_certificate" {
     stage     = terraform.workspace
   }
 }
-

--- a/global/outputs.tf
+++ b/global/outputs.tf
@@ -33,3 +33,17 @@ output "docsvcs_beanstalk_name" {
   value       = aws_elastic_beanstalk_application.docsvcs.name
 }
 
+# The IAM accounts that have also been given membership in the administrators
+# group. If we decide to use IAM groups (rather than policies) for some reason
+# for additional groups besides administrators, we should modify this code to
+# output the groups each account is given membership in.
+output "admin_accounts" {
+  description = "Names of the administrator accounts"
+  value       = aws_iam_group_membership.admins.users
+}
+
+# The IAM user accounts created.
+output "user_account_arns" {
+  description = "ARNs of the user accounts"
+  value       = aws_iam_user.users.*.arn
+}

--- a/global/r53.tf
+++ b/global/r53.tf
@@ -33,4 +33,3 @@ resource "aws_route53_zone_association" "stage" {
   zone_id = aws_route53_zone.main_priv.zone_id
   vpc_id  = module.stagevpc.vpc_id
 }
-

--- a/global/saml.tf
+++ b/global/saml.tf
@@ -2,4 +2,3 @@ resource "aws_iam_saml_provider" "mit" {
   name                   = "IdP"
   saml_metadata_document = file("files/MIT-IdP-metadata.xml")
 }
-

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -1,0 +1,15 @@
+# A subset list of IAM accounts from the "users" list to give membership in
+# the administrators group
+variable "admins" {
+  description = "A list of IAM accounts to add to the administrators group"
+  type        = "list"
+  default     = []
+}
+
+# A list of IAM accounts to create (usernames) including accounts to be
+# added to the administrators group
+variable "users" {
+  description = "A list of IAM accounts to create (usernames)"
+  type        = "list"
+  default     = []
+}

--- a/global/versions.tf
+++ b/global/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
This is a rewrite of our global IAM code. Since many of our IAM accounts and groups are from ~2017 (pre-terraform), we'll need to wait until we start the accounts=>policies and other security related cleanups to delete and recreate (or import) all those old accounts. I also added docs with our template for the global space and cleaned up some whitespace (fmt, etc).