### PR TITLE
Remove deploy key from terraform

### DIFF
--- a/apps/carbon/carbon.tf
+++ b/apps/carbon/carbon.tf
@@ -246,7 +246,3 @@ resource "aws_iam_user_policy_attachment" "deploy_ecr" {
   user       = "${aws_iam_user.deploy.name}"
   policy_arn = "${module.ecr.policy_readwrite_arn}"
 }
-
-resource "aws_iam_access_key" "deploy" {
-  user = "${aws_iam_user.deploy.name}"
-}

--- a/apps/carbon/outputs.tf
+++ b/apps/carbon/outputs.tf
@@ -2,14 +2,3 @@ output "deploy_user" {
   value       = "${aws_iam_user.deploy.name}"
   description = "Name of the IAM deploy user"
 }
-
-output "access_key_id" {
-  value       = "${aws_iam_access_key.deploy.id}"
-  description = "Access key for deploy user"
-}
-
-output "secret_access_key" {
-  value       = "${aws_iam_access_key.deploy.secret}"
-  description = "Secret key for deploy user"
-  sensitive   = true
-}


### PR DESCRIPTION
This key can't be rotated through terraform, so I'm removing it from the
config. It needs to be manually managed.