### PR TITLE
Use the correct security group for public LB

### DIFF
--- a/apps/analytics/analytics.tf
+++ b/apps/analytics/analytics.tf
@@ -18,7 +18,7 @@ locals {
 
   shared_alb_sgids = {
     "stage" = "${module.shared.alb_restricted_sgid}"
-    "prod"  = "${module.shared.alb_public_all_ingress_sgid}"
+    "prod"  = "${module.shared.alb_public_sgid}"
   }
 }
 


### PR DESCRIPTION
I'm not sure why that all ingress security group exists. I don't think
I've ever used it. This changes the the security group for the public
load balancer to the one that works.