### PR TITLE
Manage all users through Terraform

### DIFF
--- a/global/iam.tf
+++ b/global/iam.tf
@@ -1,11 +1,15 @@
 # Create IAM user accounts
 resource "aws_iam_user" "users" {
-  count = length(var.users)
-  name  = element(var.users, count.index)
+  for_each = toset(var.users)
+  name     = each.key
 
   # Do not delete the account if the user has created non-terraform managed
   # access keys that may be in use.
   force_destroy = false
+}
+
+resource "aws_iam_group" "admins" {
+  name = "Administrators"
 }
 
 # Give the IAM accounts listed in the "admins" variable list membership in
@@ -14,5 +18,10 @@ resource "aws_iam_group_membership" "admins" {
   name = "Infrastructure Administrators"
 
   users = var.admins
-  group = "Administrators"
+  group = aws_iam_group.admins.name
+}
+
+resource "aws_iam_group_policy_attachment" "admins" {
+  group      = aws_iam_group.admins.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/global/outputs.tf
+++ b/global/outputs.tf
@@ -41,9 +41,3 @@ output "admin_accounts" {
   description = "Names of the administrator accounts"
   value       = aws_iam_group_membership.admins.users
 }
-
-# The IAM user accounts created.
-output "user_account_arns" {
-  description = "ARNs of the user accounts"
-  value       = aws_iam_user.users.*.arn
-}

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -2,7 +2,7 @@
 # the administrators group
 variable "admins" {
   description = "A list of IAM accounts to add to the administrators group"
-  type        = "list"
+  type        = list
   default     = []
 }
 
@@ -10,6 +10,6 @@ variable "admins" {
 # added to the administrators group
 variable "users" {
   description = "A list of IAM accounts to create (usernames)"
-  type        = "list"
+  type        = list
   default     = []
 }


### PR DESCRIPTION
This brings all of our users into Terraform. I have switched from using
count to for_each to handle the user list. This is primarily because
with count the order of the listing matters and inserting a user anwhere
in the middle or the beginning of the list would lead to problems. A
side effect of this change is that we can't use the splat operator in
the output. I have just removed the output of users because I don't
believe this output is actually needed.

I've also imported our current group membership/policy structure so that
this too is managed by Terraform.