### PR TITLE
Code changes to allow ec2 instance type change with tfvars file change

### DIFF
--- a/apps/archivematica/README.md
+++ b/apps/archivematica/README.md
@@ -1,31 +1,34 @@
 # Archivematica Application Server
 
-This folder contains AWS resources needed for an Archivematica application stack. The Libraries uses this AWS infrastructure for testing and development while maintaining a separate bare metal on-site stack
+This folder contains the AWS resources needed for an Archivematica application stack. The Libraries uses this AWS infrastructure for testing and development while maintaining a separate bare metal on-site stack.
 
 ### What's created?:
-* An ec2 instance
+* An EC2 instance
 * An EFS instance for some test archival content
 * A Route53 DNS entry for the Archivematica server
 
 ### Additional Info:
-* Access is restricted access based on other security group membership
-* SSH access is currently allowed from outside the VPC but should likely be prevented in the future
-* The vendor requires an instance size that is at least 2CPUs and 8G of RAM
+* EFS access is restricted based on security group membership
+* This application lacks local Ansible code because a vendor configuration Playbook is used
 
 ## Input Variables
-
 | Name | Description |
 |------|-------------|
-| access\_subnets | Subnets to allow TCP/IP access |
-| dns\_zone\_id | The zone in which to create the DNS records |
 | ec2\_ami | The AMI to use for the EC2 instance |
-| ec2\_subnet | Subnet to use for the EC2 instance's IP address |
-| efs\_subnet | The subnet to use for the EFS IP address |
-| enabled | Enable or disable Route53 changes |
-| mount | The location on the EC2 server to mount the EFS instance |
+| ec2\_inst\_type | The instance type for the EC2 instance |
+| ec2\_key\_name | SSH key to assign to the EC2 instance |
+| ec2\_subnet | Subnet to use for the EC2 instance IP address |
+| ec2\_vol\_size | The EC2 volume size to use for the instance |
+| ec2\_vol\_type | The EC2 volume type to use for the instance |
+| efs\_mount | The location on the EC2 server to mount the EFS instance |
+| efs\_subnet | The subnet to use for the EFS mount target |
+| r53\_dns\_zone\_id | The ID of the zone in which to create the DNS record |
+| r53\_enabled | Enable or disable Route53 changes |
+| sec\_ss\_access\_subnets | Subnets to allow access to the Archivematica Storage Service web UI |
+| sec\_ssh\_access\_subnets | Subnets to allow SSH access |
+| sec\_web\_access\_subnets | Subnets to allow access to the Archivematica web UI |
 
 ## Outputs
-
 | Name | Description |
 |------|-------------|
 | eip_public_address | Elasic IP address of the EC2 instance |

--- a/apps/archivematica/archivematica.tf
+++ b/apps/archivematica/archivematica.tf
@@ -4,46 +4,42 @@ module "label" {
 }
 
 # Security Group for the ec2 instance
-# In staging, this security group should limit access to all systems to
-# MIT and Artefactual. In production, this security group should limit
-# access to SSH and the Storage Server (port 8000) to MIT and Artefactual
-# and allow public access to web service (port 80 and port 443)
 resource "aws_security_group" "default" {
   name        = "${module.label.name}-sg"
   description = "${module.label.name} ec2 security group"
   tags        = module.label.tags
   vpc_id      = module.shared.vpc_id
 
-  # Limit SSH to MIT and vendor only
+  # Port 22 SSH
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = var.access_subnets
+    cidr_blocks = var.sec_ssh_access_subnets
   }
 
-  # Limit port 80 web to MIT and vendor only
+  # Port 80 web UI
   ingress {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = var.access_subnets
+    cidr_blocks = var.sec_web_access_subnets
   }
 
-  # Limit port 443 web to MIT and vendor only
+  # Port 443 web UI
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = var.access_subnets
+    cidr_blocks = var.sec_web_access_subnets
   }
 
-  # Limit port 8000 Archivematica Storage Service web UI to MIT and vendor only
+  # Port 8000 Archivematica Storage Service web UI
   ingress {
     from_port   = 8000
     to_port     = 8000
     protocol    = "tcp"
-    cidr_blocks = var.access_subnets
+    cidr_blocks = var.sec_ss_access_subnets
   }
 
   egress {
@@ -56,23 +52,19 @@ resource "aws_security_group" "default" {
 
 # The ec2 Instance
 # This ec2 host will be used to run a webserver, database, and cache server
-# to power the Archivematica product. The EBS OS disk is somewhat large
-# because the database and cache data will be stored on it.
+# to power the Archivematica product.
 resource "aws_instance" "default" {
-  # 2x8GB instance is required by the vendor
-  instance_type = "t2.large"
-  # Ubuntu 18.04 LTS x86-64
-  ami = var.ec2_ami
+  instance_type = var.ec2_inst_type
+  ami           = var.ec2_ami
 
   subnet_id              = var.ec2_subnet
   vpc_security_group_ids = [aws_security_group.default.id]
-  key_name               = "vab-aws"
+  key_name               = var.ec2_key_name
   tags                   = module.label.tags
 
-  # OS disk limited to 30G since archival data will be stored on EFS
   root_block_device {
-    volume_type = "standard"
-    volume_size = "30"
+    volume_type = var.ec2_vol_type
+    volume_size = var.ec2_vol_size
   }
 }
 
@@ -85,10 +77,10 @@ resource "aws_eip" "default" {
 # DNS Record for the ec2 Host
 resource "aws_route53_record" "default" {
   name    = module.label.name
-  zone_id = var.dns_zone_id
+  zone_id = var.r53_dns_zone_id
   type    = "A"
   ttl     = "300"
 
   records = [aws_eip.default.public_ip]
-  count   = var.enabled == "true" ? 1 : 0
+  count   = var.r53_enabled == "true" ? 1 : 0
 }

--- a/apps/archivematica/efs.tf
+++ b/apps/archivematica/efs.tf
@@ -1,10 +1,10 @@
-# EFS File system used for the Archivematica App processing folders
+# EFS File system used for the Archivematica App processing folders.
 resource "aws_efs_file_system" "default" {
   creation_token = "${module.label.name}-efs"
   tags           = module.label.tags
 }
 
-# A virtual NFS servers to serve the EFS file system. We use an internal
+# A virtual NFS server to serve the EFS file system. We use an internal
 # subnet from the VPC to prevent outside access.
 resource "aws_efs_mount_target" "default" {
   file_system_id  = aws_efs_file_system.default.id
@@ -45,6 +45,6 @@ data "template_file" "default" {
 
   vars = {
     efs_dns   = aws_efs_file_system.default.dns_name
-    efs_mount = var.mount
+    efs_mount = var.efs_mount
   }
 }

--- a/apps/archivematica/main.tf
+++ b/apps/archivematica/main.tf
@@ -7,7 +7,7 @@ provider "template" {
   version = "~> 2.1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
   required_version = ">= 0.12"
 

--- a/apps/archivematica/outputs.tf
+++ b/apps/archivematica/outputs.tf
@@ -4,6 +4,6 @@ output "eip_public_address" {
 }
 
 output "hostname" {
-  description = "Hostname of the Archivematica ec2 application server"
+  description = "Hostname of the Archivematica EC2 application server"
   value       = [aws_route53_record.default.*.fqdn]
 }

--- a/apps/archivematica/variables.tf
+++ b/apps/archivematica/variables.tf
@@ -1,45 +1,84 @@
-# Global variables
+# EC2 variables
 variable "ec2_ami" {
   description = "The AMI to use for the EC2 instance"
   type        = string
   default     = ""
 }
 
+variable "ec2_inst_type" {
+  description = "The instance type for the EC2 instance"
+  type        = string
+  default     = ""
+}
+
+variable "ec2_key_name" {
+  description = "SSH key to assign to the EC2 instance"
+  type        = string
+  default     = ""
+}
+
 variable "ec2_subnet" {
-  description = "Subnet to use for EC2 instance"
+  description = "Subnet to use for the EC2 instance IP address"
   type        = string
   default     = ""
 }
 
-# Security variables
-variable "access_subnets" {
-  description = "Subnets to allow TCP/IP access"
-  type        = list(string)
-  default     = []
-
-}
-
-# Route53 variables
-variable "enabled" {
-  description = "Set to false to prevent the module from creating any resources"
-  default     = "true"
-}
-
-variable "dns_zone_id" {
-  description = "The ID of the DNS Zone in Route53 where a new DNS record will be created"
+variable "ec2_vol_size" {
+  description = "The EC2 volume size to use for the instance"
   type        = string
   default     = ""
 }
+
+variable "ec2_vol_type" {
+  description = "The EC2 volume type to use for the instance"
+  type        = string
+  default     = ""
+}
+
 
 # EFS variables
-variable "efs_subnet" {
-  description = "The subnet for the EFS mount target"
-  type        = string
-  default     = ""
-}
-
-variable "mount" {
+variable "efs_mount" {
   description = "The location on the EC2 server to mount the EFS instance"
   type        = string
   default     = ""
+}
+
+variable "efs_subnet" {
+  description = "The subnet to use for the EFS mount target"
+  type        = string
+  default     = ""
+}
+
+
+# Route53 variables
+
+variable "r53_dns_zone_id" {
+  description = "The ID of the zone in which to create the DNS record"
+  type        = string
+  default     = ""
+}
+
+variable "r53_enabled" {
+  description = "Enable or disable Route53 changes"
+  default     = "true"
+}
+
+
+# Security Group variables
+variable "sec_ss_access_subnets" {
+  description = "Subnets to allow access to the Archivematica Storage Service web UI"
+  type        = list(string)
+  default     = []
+}
+
+variable "sec_ssh_access_subnets" {
+  description = "Subnets to allow SSH access"
+  type        = list(string)
+  default     = []
+}
+
+variable "sec_web_access_subnets" {
+  description = "Subnets to allow access to the Archivematica web UI"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
These changes will allow me to use Terraform to change the instance type for the Archivematica staging server from a type t2 to a type t3a. The new type t3a instances are about 20% cheaper than type t2 instances. As part of these changes, I also did a good amount of code and documentation cleanup.