### PR TITLE
upgrade libstaff to v0.12

### DIFF
--- a/apps/libstaff/README.md
+++ b/apps/libstaff/README.md
@@ -2,6 +2,16 @@
 
 *Note: This is only created in our Terraform `prod` workspace*
 
-This app is used to create an S3 hosted website for the old libstaff.mit.edu content. The old libstaff server has been shutdown, and a backup copy of the content has been uploaded to the `libstaff-archive.mitlib.net` S3 bucket. A majority of this content is static HTML and accessible via the web by visiting http://libstaff-archive.mitlib.net (*Restricted to VPN*).
+This app is used to create an S3 hosted website for the legacy libstaff.mit.edu content. The content has been uploaded to the `libstaff-archive.mitlib.net` S3 bucket. A majority of this content is static HTML and accessible via the web by visiting http://libstaff-archive.mitlib.net (*Restricted to MIT VPN*).
 
-If content is unviewable or inaccessible by visiting the link above, you may download files directly from the AWS GUI or via the command line using the AWS CLI.
+If content is inaccessible by visiting the link above, you may download files directly from the AWS GUI or via the command line using the AWS CLI.
+
+### What's Created
+* IAm policy that restricts S3 bucket access to MIT's VPN subnets
+* Route53 DNS entry for the Libstaff webserver in the mitlib.net zone
+* S3 bucket to store the Libstaff website data
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| sec\_web\_access\_subnets | Subnets to allow access to the Libstaff website | list(string) | n/a | yes |

--- a/apps/libstaff/libstaff.tf
+++ b/apps/libstaff/libstaff.tf
@@ -1,17 +1,14 @@
 module "website" {
-  source         = "github.com/mitlibraries/tf-mod-s3-website?ref=0.11"
-  name           = "libstaff-archive"
-  hostname       = "libstaff-archive.mitlib.net"
-  parent_zone_id = "${module.shared.public_zoneid}"
-}
-
-resource "aws_s3_bucket_policy" "default" {
-  bucket = "${module.website.s3_bucket_name}"
-  policy = "${data.aws_iam_policy_document.default.json}"
+  source             = "github.com/mitlibraries/tf-mod-s3-website?ref=0.12"
+  name               = "libstaff-archive"
+  hostname           = "libstaff-archive.mitlib.net"
+  parent_zone_id     = module.shared.public_zoneid
+  force_destroy      = false
+  versioning_enabled = false
 }
 
 data "aws_iam_policy_document" "default" {
-  statement = [{
+  statement {
     actions = ["s3:GetObject"]
 
     resources = ["${module.website.s3_bucket_arn}/*"]
@@ -25,7 +22,12 @@ data "aws_iam_policy_document" "default" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
-      values = ["18.28.0.0/16", "18.30.0.0/16"]
+      values = var.sec_web_access_subnets
     }
-  }]
+  }
+}
+
+resource "aws_s3_bucket_policy" "default" {
+  bucket = module.website.s3_bucket_name
+  policy = data.aws_iam_policy_document.default.json
 }

--- a/apps/libstaff/main.tf
+++ b/apps/libstaff/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }

--- a/apps/libstaff/variables.tf
+++ b/apps/libstaff/variables.tf
@@ -1,0 +1,6 @@
+# Security variables
+
+variable "sec_web_access_subnets" {
+  description = "Subnets to allow access to the Libstaff website"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the libstaff infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code
2. A new variable was added for the access subnets so that a code review is not required if IS&T changes the VPN subnets
3. Addition of a couple variable value definitions for the S3 website module that TF now requires

This code was run through a `_terraform fmt_` and shows no differences when run through a `_terraform plan_`.