### PR TITLE
upgrade archivesspace to v0.12

### DIFF
--- a/apps/archivesspace/README.md
+++ b/apps/archivesspace/README.md
@@ -1,0 +1,20 @@
+# ArchivesSpace SaaS Application
+
+This folder contains the AWS resources needed to support the ArchivesSpace SaaS application. ArchivesSpace is a web based archives information management system.
+
+This infrastructure currently consists of DNS CName entries in the mitlib.net zone that allow mit.edu zone CNames to be redirected to DNS CName records at the SaaS provider. The use of the mitlib.net zone CNames provides a layer of abstraction that allows MIT Libraries to make vendor requested DNS changes with out requiring updates to the mit.edu zone files.
+
+### Additional Info
+* This infrastructure is only created in our Terraform `prod` workspace.
+
+### What's Created
+* Route53 mitlib.net CName records.
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_archivesspace\_cname\_public\_value | The archivesspace public CName DNS record value | list(string) | n/a | yes |
+| r53\_archivesspace-staff\_cname\_public\_value | The archivesspace\-staff public CName DNS record value | list(string) | n/a | yes |
+| r53\_emmas\-lib\_cname\_public\_value | The emmas\-lib public CName DNS record value | list(string) | n/a | yes |
+| r53\_emmastaff\-lib\_cname\_public\_value | The emmastaff\-lib public CName DNS record value | list(string) | n/a | yes |
+| r53\_archivesspace\_cname\_private\_value | The archivesspace private CName DNS record value | list(string) | n/a | yes |

--- a/apps/archivesspace/as.tf
+++ b/apps/archivesspace/as.tf
@@ -3,7 +3,7 @@ resource "aws_route53_record" "as" {
   ttl     = 3600
   type    = "CNAME"
   zone_id = module.shared.public_zoneid
-  records = ["as-prod-general-app4.LYRTECH.ORG"]
+  records = var.r53_archivesspace_cname_public_value
 }
 
 resource "aws_route53_record" "astaff" {
@@ -11,7 +11,7 @@ resource "aws_route53_record" "astaff" {
   ttl     = 3600
   type    = "CNAME"
   zone_id = module.shared.public_zoneid
-  records = ["as-prod-general-app4.LYRTECH.ORG"]
+  records = var.r53_archivesspace-staff_cname_public_value
 }
 
 resource "aws_route53_record" "emma" {
@@ -19,7 +19,7 @@ resource "aws_route53_record" "emma" {
   ttl     = 600
   type    = "CNAME"
   zone_id = module.shared.public_zoneid
-  records = ["as-prod-general-app4.LYRTECH.ORG"]
+  records = var.r53_emmas-lib_cname_public_value
 }
 
 resource "aws_route53_record" "emmastaff" {
@@ -27,7 +27,7 @@ resource "aws_route53_record" "emmastaff" {
   ttl     = 600
   type    = "CNAME"
   zone_id = module.shared.public_zoneid
-  records = ["as-prod-general-app4.LYRTECH.ORG"]
+  records = var.r53_emmastaff-lib_cname_public_value
 }
 
 resource "aws_route53_record" "as_private" {
@@ -35,5 +35,5 @@ resource "aws_route53_record" "as_private" {
   ttl     = 3600
   type    = "CNAME"
   zone_id = module.shared.private_zoneid
-  records = ["as-prod-general-app4.LYRTECH.ORG"]
+  records = var.r53_archivesspace_cname_private_value
 }

--- a/apps/archivesspace/main.tf
+++ b/apps/archivesspace/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -19,4 +19,3 @@ terraform {
 module "shared" {
   source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }
-

--- a/apps/archivesspace/variables.tf
+++ b/apps/archivesspace/variables.tf
@@ -1,0 +1,25 @@
+# Route53 variables
+variable "r53_archivesspace_cname_public_value" {
+  description = "The archivesspace public CName DNS record value"
+  type        = list(string)
+}
+
+variable "r53_archivesspace-staff_cname_public_value" {
+  description = "The archivesspace-staff public CName DNS record value"
+  type        = list(string)
+}
+
+variable "r53_emmas-lib_cname_public_value" {
+  description = "The emmas-lib public CName DNS record value"
+  type        = list(string)
+}
+
+variable "r53_emmastaff-lib_cname_public_value" {
+  description = "The emmastaff-lib public CName DNS record value"
+  type        = list(string)
+}
+
+variable "r53_archivesspace_cname_private_value" {
+  description = "The archivesspace private CName DNS record value"
+  type        = list(string)
+}

--- a/apps/archivesspace/versions.tf
+++ b/apps/archivesspace/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
This upgrades the archivesspace infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code
2. Vendor CName record information was moved to a tfvars file so that a code review is not required if the vendor requests a DNS chagne.

This code was run through a _terraform fmt_ and shows no differences when run through a _terraform plan_.