### PR TITLE
upgrade dpworkshop to v0.12

### DIFF
--- a/apps/dpworkshop/README.md
+++ b/apps/dpworkshop/README.md
@@ -2,11 +2,22 @@
 
 This folder contains AWS Route53 records for dpworkshop.org sites hosted on [Pantheon](https://pantheon.io/).
 
+### Additional Info:
+* This infrastructure is only created in our Terraform `prod` workspace.
+
 ### What's created?:
 * dpworkshop.org Route53 Hosted zone
 * Associated NS and SOA records for the dpworkshop.org domain
-* 3 x Route53 DNS records for dev, test, and live (dpworkshop.org)
-* 3 x Route53 DNS record for dev, test, and live (tdr.dpworkshop.org)
+* Route53 DNS records for dev, test, and prod (dpworkshop.org)
+* Route53 DNS records for dev, test, and prod (tdr.dpworkshop.org)
 
-### Additional Info:
-* dpworkshop sites are only deployed to the Terraform `prod` workspace
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_dpworkshop\_prod_value | The prod dpworkshop.org website DNS record value | list(string) | n/a | yes |
+| r53\_dpworkshop\_prod\_ipv6_value | The prod dpworkshop.org website IPv6 DNS record value | list(string) | n/a | yes |
+| r53\_dpworkshop\_dev\_value | The dev.dpworkshop.org website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_dpworkshop\_test\_value | The test.dpworkshop.org website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_tdr\_value | The prod tdr.dpworkshop.org Trac website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_tdr\_dev\_value | The tdr\-dev.dpworkshop.org Trac website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_tdr\_test\_value | The tdr\-test.dpworkshop.org Trac website DNS CNAME record value | list(string) | n/a | yes |

--- a/apps/dpworkshop/dpworkshop.tf
+++ b/apps/dpworkshop/dpworkshop.tf
@@ -1,5 +1,4 @@
-# Create dpworkshop.org hosted zone and associated DNS entries
-
+# Create dpworkshop.org hosted zone and associated DNS entries.
 resource "aws_route53_zone" "dpworkshop" {
   name = "dpworkshop.org"
 
@@ -11,22 +10,22 @@ resource "aws_route53_zone" "dpworkshop" {
 }
 
 resource "aws_route53_record" "dpworkshop-ns" {
-  zone_id = "${aws_route53_zone.dpworkshop.zone_id}"
-  name    = "${aws_route53_zone.dpworkshop.name}"
+  zone_id = aws_route53_zone.dpworkshop.zone_id
+  name    = aws_route53_zone.dpworkshop.name
   type    = "NS"
   ttl     = "86400"
 
   records = [
-    "${aws_route53_zone.dpworkshop.name_servers.0}",
-    "${aws_route53_zone.dpworkshop.name_servers.1}",
-    "${aws_route53_zone.dpworkshop.name_servers.2}",
-    "${aws_route53_zone.dpworkshop.name_servers.3}",
+    aws_route53_zone.dpworkshop.name_servers.0,
+    aws_route53_zone.dpworkshop.name_servers.1,
+    aws_route53_zone.dpworkshop.name_servers.2,
+    aws_route53_zone.dpworkshop.name_servers.3,
   ]
 }
 
 resource "aws_route53_record" "dpworkshop-soa" {
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  name    = "${aws_route53_zone.dpworkshop.name}"
+  zone_id = aws_route53_zone.dpworkshop.id
+  name    = aws_route53_zone.dpworkshop.name
   type    = "SOA"
   ttl     = "900"
 
@@ -35,60 +34,60 @@ resource "aws_route53_record" "dpworkshop-soa" {
   ]
 }
 
-# Create dpworkshop.org DNS entries
+# Create dpworkshop.org DNS entries.
 resource "aws_route53_record" "dpworkshop-web" {
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  name    = "${aws_route53_zone.dpworkshop.name}"
+  zone_id = aws_route53_zone.dpworkshop.id
+  name    = aws_route53_zone.dpworkshop.name
   type    = "A"
-  ttl     = "300"
-  records = ["23.185.0.3"]
+  ttl     = 300
+  records = var.r53_dpworkshop_prod_value
 }
 
 resource "aws_route53_record" "dpworkshop-web1" {
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  name    = "${aws_route53_zone.dpworkshop.name}"
+  zone_id = aws_route53_zone.dpworkshop.id
+  name    = aws_route53_zone.dpworkshop.name
   type    = "AAAA"
-  ttl     = "300"
-  records = ["2620:12a:8000::3", "2620:12a:8001::3"]
+  ttl     = 300
+  records = var.r53_dpworkshop_prod_ipv6_value
 }
 
 resource "aws_route53_record" "dpworkshop_dev" {
   name    = "dev"
-  ttl     = 300
   type    = "CNAME"
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  records = ["dev-mitlib-dpworkshop.pantheonsite.io"]
+  ttl     = 300
+  zone_id = aws_route53_zone.dpworkshop.id
+  records = var.r53_dpworkshop_dev_value
 }
 
 resource "aws_route53_record" "dpworkshop_test" {
   name    = "test"
-  ttl     = 300
   type    = "CNAME"
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  records = ["test-mitlib-dpworkshop.pantheonsite.io"]
+  ttl     = 300
+  zone_id = aws_route53_zone.dpworkshop.id
+  records = var.r53_dpworkshop_test_value
 }
 
-# Create TDR Demo DNS entries
+# Create TDR Demo DNS entries.
 resource "aws_route53_record" "tdr" {
   name    = "tdr"
-  ttl     = 300
   type    = "CNAME"
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  records = ["live-mitlib-trac-demo.pantheonsite.io"]
+  ttl     = 300
+  zone_id = aws_route53_zone.dpworkshop.id
+  records = var.r53_tdr_value
 }
 
 resource "aws_route53_record" "tdr_dev" {
   name    = "tdr-dev"
-  ttl     = 300
   type    = "CNAME"
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  records = ["dev-mitlib-trac-demo.pantheonsite.io"]
+  ttl     = 300
+  zone_id = aws_route53_zone.dpworkshop.id
+  records = var.r53_tdr_dev_value
 }
 
 resource "aws_route53_record" "tdr_test" {
   name    = "tdr-test"
-  ttl     = 300
   type    = "CNAME"
-  zone_id = "${aws_route53_zone.dpworkshop.id}"
-  records = ["test-mitlib-trac-demo.pantheonsite.io"]
+  ttl     = 300
+  zone_id = aws_route53_zone.dpworkshop.id
+  records = var.r53_tdr_test_value
 }

--- a/apps/dpworkshop/main.tf
+++ b/apps/dpworkshop/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 #Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"

--- a/apps/dpworkshop/variables.tf
+++ b/apps/dpworkshop/variables.tf
@@ -1,0 +1,35 @@
+# Route53 variables
+variable "r53_dpworkshop_prod_value" {
+  description = "The prod dpworkshop.org website DNS record value"
+  type        = list(string)
+}
+
+variable "r53_dpworkshop_prod_ipv6_value" {
+  description = "The prod dpworkshop.org website IPv6 DNS record value"
+  type        = list(string)
+}
+
+variable "r53_dpworkshop_dev_value" {
+  description = "The dev.dpworkshop.org website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_dpworkshop_test_value" {
+  description = "The test.dpworkshop.org website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_tdr_value" {
+  description = "The prod tdr.dpworkshop.org Trac website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_tdr_dev_value" {
+  description = "The tdr-dev.dpworkshop.org Trac website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_tdr_test_value" {
+  description = "The tdr-test.dpworkshop.org Trac website DNS CNAME record value"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the dpworkshop infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.
2. Vendor DNS record information was moved to a tfvars file so that a code review is not required if the vendor requests a DNS change.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.