### PR TITLE
upgrade similewidgets to v0.12

### DIFF
--- a/apps/similewidgets/README.md
+++ b/apps/similewidgets/README.md
@@ -1,11 +1,18 @@
 # Simile-widgets
-
-This folder contains AWS Route53 records for simile-widgets.org currently hosted on AWS
+This folder contains AWS Route53 records for the simile-widgets.org websites.
 
 ### What's created?:
-* simile-widgets.org Route53 Hosted zone
-* Associated NS and SOA records for the simile-widgets.org domain
-* Associated DNS entries for simile-widgets.org
+* Route53 zone for simile-widgets.org
+* Route53 NS and SOA DNS records for the simile-widgets.org domain
+* Route53 DNS A record entries for simile-widgets.org websites
 
 ### Additional Info:
-* simile-widgets.org Route53 setup is only deployed to the Terraform `prod` workspace
+* This infrastructure is only created in our Terraform `prod` workspace.
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_api\_value | The api.simile\-widgets.org website DNS record value | list(string) | n/a | yes |
+| r53\_service\_value | The service.simile\-widgets.org website DNS record value | list(string) | n/a | yes |
+| r53\_trunk\_value | The trunk.simile\-widgets.org website DNS record value | list(string) | n/a | yes |
+| r53\_web\_value | The simile\-widgets.org website DNS record value | list(string) | n/a | yes |

--- a/apps/similewidgets/main.tf
+++ b/apps/similewidgets/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"

--- a/apps/similewidgets/similewidgets.tf
+++ b/apps/similewidgets/similewidgets.tf
@@ -1,4 +1,4 @@
-# Add hosted zone and DNS entry for simile-widgets.org
+# Create zone.
 resource "aws_route53_zone" "simile" {
   name = "simile-widgets.org"
 
@@ -9,59 +9,62 @@ resource "aws_route53_zone" "simile" {
   }
 }
 
+# Set up name server records.
 resource "aws_route53_record" "simile-ns" {
-  zone_id = "${aws_route53_zone.simile.zone_id}"
-  name    = "${aws_route53_zone.simile.name}"
+  zone_id = aws_route53_zone.simile.zone_id
+  name    = aws_route53_zone.simile.name
   type    = "NS"
-  ttl     = "86400"
+  ttl     = 86400
 
   records = [
-    "${aws_route53_zone.simile.name_servers.0}",
-    "${aws_route53_zone.simile.name_servers.1}",
-    "${aws_route53_zone.simile.name_servers.2}",
-    "${aws_route53_zone.simile.name_servers.3}",
+    aws_route53_zone.simile.name_servers.0,
+    aws_route53_zone.simile.name_servers.1,
+    aws_route53_zone.simile.name_servers.2,
+    aws_route53_zone.simile.name_servers.3,
   ]
 }
 
+# Set up SOA.
 resource "aws_route53_record" "simile-soa" {
-  zone_id = "${aws_route53_zone.simile.id}"
-  name    = "${aws_route53_zone.simile.name}"
+  zone_id = aws_route53_zone.simile.id
+  name    = aws_route53_zone.simile.name
   type    = "SOA"
-  ttl     = "900"
+  ttl     = 900
 
   records = [
     "${aws_route53_zone.simile.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
   ]
 }
 
-resource "aws_route53_record" "simile-web" {
-  zone_id = "${aws_route53_zone.simile.id}"
-  name    = "${aws_route53_zone.simile.name}"
+# Create DNS entries for websites.
+resource "aws_route53_record" "simile-api" {
+  zone_id = aws_route53_zone.simile.id
+  name    = "api.${aws_route53_zone.simile.name}"
   type    = "A"
-  ttl     = "300"
-  records = ["18.23.238.206"]
-}
-
-resource "aws_route53_record" "simile-trunk" {
-  zone_id = "${aws_route53_zone.simile.id}"
-  name    = "trunk.${aws_route53_zone.simile.name}"
-  type    = "A"
-  ttl     = "300"
-  records = ["18.23.238.206"]
+  ttl     = 300
+  records = var.r53_api_value
 }
 
 resource "aws_route53_record" "simile-service" {
-  zone_id = "${aws_route53_zone.simile.id}"
+  zone_id = aws_route53_zone.simile.id
   name    = "service.${aws_route53_zone.simile.name}"
   type    = "A"
-  ttl     = "300"
-  records = ["18.23.238.65"]
+  ttl     = 300
+  records = var.r53_service_value
 }
 
-resource "aws_route53_record" "simile-api" {
-  zone_id = "${aws_route53_zone.simile.id}"
-  name    = "api.${aws_route53_zone.simile.name}"
+resource "aws_route53_record" "simile-trunk" {
+  zone_id = aws_route53_zone.simile.id
+  name    = "trunk.${aws_route53_zone.simile.name}"
   type    = "A"
-  ttl     = "300"
-  records = ["18.23.238.99"]
+  ttl     = 300
+  records = var.r53_trunk_value
+}
+
+resource "aws_route53_record" "simile-web" {
+  zone_id = aws_route53_zone.simile.id
+  name    = aws_route53_zone.simile.name
+  type    = "A"
+  ttl     = 300
+  records = var.r53_web_value
 }

--- a/apps/similewidgets/variables.tf
+++ b/apps/similewidgets/variables.tf
@@ -1,0 +1,20 @@
+# Route53 variables
+variable "r53_api_value" {
+  description = "The api.simile-widgets.org website DNS record value"
+  type        = list(string)
+}
+
+variable "r53_service_value" {
+  description = "The service.simile-widgets.org website DNS record value"
+  type        = list(string)
+}
+
+variable "r53_trunk_value" {
+  description = "The trunk.simile-widgets.org website DNS record value"
+  type        = list(string)
+}
+
+variable "r53_web_value" {
+  description = "The simile-widgets.org website DNS record value"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the similewidgets infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.
2. DNS record information was moved to a tfvars file so that a code review is not required for a DNS change.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.