### PR TITLE
upgrade build system to tf v0.12.29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - TF_VERSION=0.12.9
+  - TF_VERSION=0.12.29
 before_install:
   - wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -O /tmp/tf.zip
   - unzip -d bin/ /tmp/tf.zip


### PR DESCRIPTION
This PR upgrades the TerraForm version the Travis build system uses to v0.12.29 (released 2020-07-22). Currently, the system is using v0.12.9 that was released back on 2019-09-17 (about a year ago). There are some changes between v0.12.9 and v0.12.29 that could cause runtime warnings and possibly some issues in the future. Christopher has said he would like us to stay on the v0.12.x branch, for now, and hold off on moving to the v0.13.x branch. Upgrading the build version to the most recent v0.12.x release should make it easier for us to move to centralized deployment model and for us to eventually upgrade to v0.13.

The modules I have looked at are all also running their Travis builds against v0.12.9. However, before we go through the work of upgrading all of them, I think we should revisit our discussions about how we'd like to use modules. I believe we could likely sunset a number of the modules we're using to make our code easier to maintain, easier to work with, and more resilient.