### PR TITLE
Upgrade deploy to v0.12

### DIFF
--- a/shared/deploy/README.md
+++ b/shared/deploy/README.md
@@ -2,6 +2,9 @@
 
 This module provides a shared place for various deploy related resources. Currently, this just contains an S3 bucket that can be used for binaries needed during deploy.
 
+### What's created
+* IAm access policy for an S3 bucket
+* S3 bucket
 
 ## Outputs
 
@@ -9,4 +12,3 @@ This module provides a shared place for various deploy related resources. Curren
 |------|-------------|
 | name | Bucket name |
 | rw\_arn | Read/write policy ARN |
-

--- a/shared/deploy/deploy.tf
+++ b/shared/deploy/deploy.tf
@@ -1,4 +1,4 @@
 module "bucket" {
-  source = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.12"
   name   = "deploy-mitlib"
 }

--- a/shared/deploy/main.tf
+++ b/shared/deploy/main.tf
@@ -1,17 +1,11 @@
-/**
- * # Shared deploy resource
- *
- * This module provides a shared place for various deploy related resources. Currently, this just contains an S3 bucket that can be used for binaries needed during deploy.
- *
- **/
 provider "aws" {
   version = "~> 2.0"
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"

--- a/shared/deploy/outputs.tf
+++ b/shared/deploy/outputs.tf
@@ -1,9 +1,9 @@
 output "name" {
-  value       = "${module.bucket.bucket_id}"
+  value       = module.bucket.bucket_id
   description = "Bucket name"
 }
 
 output "rw_arn" {
-  value       = "${module.bucket.readwrite_arn}"
+  value       = module.bucket.readwrite_arn
   description = "Read/write policy ARN"
 }


### PR DESCRIPTION
This upgrades the deploy infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.