### PR TITLE
upgrade haydenreno to TF v0.12

### DIFF
--- a/apps/haydenreno/README.md
+++ b/apps/haydenreno/README.md
@@ -3,7 +3,14 @@
 This folder contains AWS Route53 records for the Hayden Renovation WordPress site hosted on [Pantheon](https://pantheon.io/).
 
 ### What's created?:
-* 3 x Route53 DNS records for dev, test, and live
+* 3 x Route53 DNS records for dev, test, and prod
 
 ### Additional Info:
 * Hayden Renovation is only deployed to the Terraform `prod` workspace
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_haydenreno\_value | The prod haydenrenonews.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_haydenreno\_dev\_value | The haydenrenonews\-dev.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_haydenreno\_test\_value | The haydenrenonews\-test.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |

--- a/apps/haydenreno/haydenreno.tf
+++ b/apps/haydenreno/haydenreno.tf
@@ -2,22 +2,22 @@ resource "aws_route53_record" "haydenrenonews" {
   name    = "haydenrenonews"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["live-haydenrenovation.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_haydenrenonews_value
 }
 
 resource "aws_route53_record" "haydenrenonews_dev" {
   name    = "haydenrenonews-dev"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["dev-haydenrenovation.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_haydenrenonews_dev_value
 }
 
 resource "aws_route53_record" "haydenrenonews_test" {
   name    = "haydenrenonews-test"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["test-haydenrenovation.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_haydenrenonews_test_value
 }

--- a/apps/haydenreno/main.tf
+++ b/apps/haydenreno/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }

--- a/apps/haydenreno/variables.tf
+++ b/apps/haydenreno/variables.tf
@@ -1,0 +1,14 @@
+variable "r53_haydenrenonews_value" {
+  description = "The prod haydenrenonews.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_haydenrenonews_dev_value" {
+  description = "The haydenrenonews-dev.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_haydenrenonews_test_value" {
+  description = "The haydenrenonews-test.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the haydenreno infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.
2. Vendor DNS record information was moved to a tfvars file so that a code review is not required if the vendor requests a DNS change.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.