### PR TITLE
upgrade fol to TF v0.12

### DIFF
--- a/apps/futureoflibraries/README.md
+++ b/apps/futureoflibraries/README.md
@@ -3,7 +3,14 @@
 This folder contains AWS Route53 records for the Future of Libraries Drupal site hosted on [Pantheon](https://pantheon.io/).
 
 ### What's created?:
-* 3 x Route53 DNS records for dev, test, and live
+* 3 x Route53 DNS records for dev, test, and prod
 
 ### Additional Info:
 * Future of Libraries is only deployed to the Terraform `prod` workspace
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_fol\_value | The prod future\-of\-libraries.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_fol\_dev\_value | The future\-of\-libraries\-dev.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_fol\_test\_value | The future\-of\-libraries\-test.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |

--- a/apps/futureoflibraries/fol.tf
+++ b/apps/futureoflibraries/fol.tf
@@ -2,22 +2,22 @@ resource "aws_route53_record" "fol" {
   name    = "future-of-libraries"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["live-mitlib-futureoflibraries.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_fol_value
 }
 
 resource "aws_route53_record" "fol_dev" {
   name    = "future-of-libraries-dev"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["dev-mitlib-futureoflibraries.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_fol_dev_value
 }
 
 resource "aws_route53_record" "fol_test" {
   name    = "future-of-libraries-test"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["test-mitlib-futureoflibraries.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_fol_test_value
 }

--- a/apps/futureoflibraries/main.tf
+++ b/apps/futureoflibraries/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }

--- a/apps/futureoflibraries/variables.tf
+++ b/apps/futureoflibraries/variables.tf
@@ -1,0 +1,14 @@
+variable "r53_fol_value" {
+  description = "The prod future-of-libraries.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_fol_dev_value" {
+  description = "The future-of-libraries-dev.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_fol_test_value" {
+  description = "The future-of-libraries-test.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the futureoflibraries infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.
2. Vendor DNS record information was moved to a tfvars file so that a code review is not required if the vendor requests a DNS change.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.