### PR TITLE
upgrade oatf to TF v0.12

### DIFF
--- a/apps/oatf/README.md
+++ b/apps/oatf/README.md
@@ -3,7 +3,14 @@
 This folder contains AWS Route53 records for the Open Access Task Force Drupal site hosted on [Pantheon](https://pantheon.io/).
 
 ### What's created?:
-* 3 x Route53 DNS records for dev, test, and live
+* 3 x Route53 DNS records for dev, test, and prod
 
 ### Additional Info:
 * Open Access Task Force is only deployed to the Terraform `prod` workspace
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_oatf\_value | The prod open\-access.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_oatf\_dev\_value | The open\-access\-dev.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_oatf\_test\_value | The open\-access\-test.mitlib.net website DNS CNAME record value | list(string) | n/a | yes |

--- a/apps/oatf/main.tf
+++ b/apps/oatf/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }

--- a/apps/oatf/oatf.tf
+++ b/apps/oatf/oatf.tf
@@ -2,22 +2,22 @@ resource "aws_route53_record" "oatf" {
   name    = "open-access"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["live-mitlib-openaccess.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_oatf_value
 }
 
 resource "aws_route53_record" "oatf_dev" {
   name    = "open-access-dev"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["dev-mitlib-openaccess.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_oatf_dev_value
 }
 
 resource "aws_route53_record" "oatf_test" {
   name    = "open-access-test"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["test-mitlib-openaccess.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_oatf_test_value
 }

--- a/apps/oatf/variables.tf
+++ b/apps/oatf/variables.tf
@@ -1,0 +1,14 @@
+variable "r53_oatf_value" {
+  description = "The prod open-access.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_oatf_dev_value" {
+  description = "The open-access-dev.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_oatf_test_value" {
+  description = "The open-access-test.mitlib.net website DNS CNAME record value"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the oatf infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.
2. Vendor DNS record information was moved to a tfvars file so that a code review is not required if the vendor requests a DNS change.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.