### PR TITLE
upgrade tdr to TF v0.12

### DIFF
--- a/apps/tdr/README.md
+++ b/apps/tdr/README.md
@@ -3,7 +3,14 @@
 This folder contains AWS Route53 records for the TDR Drupal site hosted on [Pantheon](https://pantheon.io/).
 
 ### What's created?:
-* 3 x Route53 DNS records for dev, test, and live
+* 3 x Route53 DNS records for dev, test, and prod
 
 ### Additional Info:
 * TDR is only deployed to the Terraform `prod` workspace
+
+## Input Variables
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| r53\_trac\_value | The prod tdr.mitlib.net Trac website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_trac\_dev\_value | The tdr\-dev.mitlib.net Trac website DNS CNAME record value | list(string) | n/a | yes |
+| r53\_trac\_test\_value | The tdr\-test.mitlib.net Trac website DNS CNAME record value | list(string) | n/a | yes |

--- a/apps/tdr/main.tf
+++ b/apps/tdr/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -17,5 +17,5 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }

--- a/apps/tdr/tdr.tf
+++ b/apps/tdr/tdr.tf
@@ -2,22 +2,22 @@ resource "aws_route53_record" "tdr" {
   name    = "tdr"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["live-mitlib-trac.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_trac_value
 }
 
 resource "aws_route53_record" "tdr_dev" {
   name    = "tdr-dev"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["dev-mitlib-trac.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_trac_dev_value
 }
 
 resource "aws_route53_record" "tdr_test" {
   name    = "tdr-test"
   ttl     = 300
   type    = "CNAME"
-  zone_id = "${module.shared.public_zoneid}"
-  records = ["test-mitlib-trac.pantheonsite.io"]
+  zone_id = module.shared.public_zoneid
+  records = var.r53_trac_test_value
 }

--- a/apps/tdr/variables.tf
+++ b/apps/tdr/variables.tf
@@ -1,0 +1,14 @@
+variable "r53_trac_value" {
+  description = "The prod tdr.mitlib.net Trac website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_trac_dev_value" {
+  description = "The tdr-dev.mitlib.net Trac website DNS CNAME record value"
+  type        = list(string)
+}
+
+variable "r53_trac_test_value" {
+  description = "The tdr-test.mitlib.net Trac website DNS CNAME record value"
+  type        = list(string)
+}


### PR DESCRIPTION
This upgrades the Trac (tdr) infrastructure to v0.12. This commit includes:

1. Minor syntax changes to the code.
2. Vendor DNS record information was moved to a tfvars file so that a code review is not required if the vendor requests a DNS change.

This code was run through a '_terraform fmt_' and shows no differences when run through a '_terraform plan_'.