### PR TITLE
upgrade grandchallenges to tf v0.12

### DIFF
--- a/apps/grandchallenges/grandchallenges.tf
+++ b/apps/grandchallenges/grandchallenges.tf
@@ -1,8 +1,7 @@
-#The certificate was created manually (via MIT) and imported manually
-#We will investigate options for generating SSL certificates in the future
+# The certificate was created manually (via MIT) and imported manually
 
 module "grand_web" {
-  source               = "github.com/mitlibraries/tf-mod-cdn-s3?ref=0.11"
+  source               = "github.com/mitlibraries/tf-mod-cdn-s3?ref=0.12"
   name                 = "grandchallenges"
   aliases              = ["grandchallenges.mitlib.net"]
   ext_aliases          = ["grandchallenges.mit.edu"]
@@ -11,9 +10,10 @@ module "grand_web" {
 
   custom_error_response = [
     {
-      error_code         = "404"
-      response_code      = "200"
-      response_page_path = "/index.html"
+      error_code            = "404"
+      response_code         = "200"
+      response_page_path    = "/index.html"
+      error_caching_min_ttl = "0"
     },
   ]
 

--- a/apps/grandchallenges/main.tf
+++ b/apps/grandchallenges/main.tf
@@ -3,9 +3,13 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-#Tell terraform to use the S3 bucket and DynamoDB we created
+provider "template" {
+  version = "~> 2.2"
+}
+
+# Tell terraform to use the S3 bucket and DynamoDB we created
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"


### PR DESCRIPTION
Upgrade the grandchallenges app to Terraform v0.12. There are no tfvars associated with this app. It is only deployed to prod.