### PR TITLE
ezproxy tf v0.12 upgrade

### DIFF
--- a/apps/ezproxy-lookup/README.md
+++ b/apps/ezproxy-lookup/README.md
@@ -7,9 +7,12 @@ This folder contains AWS resources needed for the deployment of the [EZproxy Loo
 * An IAM user/credentials with read only access to the S3 Bucket (used by Heroku application)
 * A role which is maintained via an MIT Moira list for staff to upload new files to the S3 bucket
 
+### Additional Info:
+* EZproxy Lookup is only deployed to the Terraform `stage` workspace
+
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| access\_key\_id | The access key ID for app to use |
-| secret\_access\_key | The secret access key for app to use. This will be written to the state file in plain-text |
+| access\_key\_id | The access key ID for app to use. |
+| secret\_access\_key | The secret access key for app to use. This will be written to the state file in plain-text. |

--- a/apps/ezproxy-lookup/ezproxy_s3.tf
+++ b/apps/ezproxy-lookup/ezproxy_s3.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source = "github.com/mitlibraries/tf-mod-name?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
   name   = "ezproxy-lookup"
 }
 
@@ -11,19 +11,19 @@ resource "aws_iam_user" "default" {
 }
 
 module "ezproxy-lookup" {
-  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.11"
+  source             = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.12"
   name               = "ezproxy-lookup"
   versioning_enabled = "true"
 }
 
 resource "aws_iam_user_policy_attachment" "default_ro" {
-  user       = "${aws_iam_user.default.name}"
-  policy_arn = "${module.ezproxy-lookup.readonly_arn}"
+  user       = aws_iam_user.default.name
+  policy_arn = module.ezproxy-lookup.readonly_arn
 }
 
 # Generate API credentials
 resource "aws_iam_access_key" "default" {
-  user = "${aws_iam_user.default.name}"
+  user = aws_iam_user.default.name
 }
 
 # Create a role with admin access for managing ezproxy lookup S3 bucket
@@ -55,6 +55,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {
-  role       = "${aws_iam_role.ezproxy-lookup.name}"
-  policy_arn = "${module.ezproxy-lookup.admin_arn}"
+  role       = aws_iam_role.ezproxy-lookup.name
+  policy_arn = module.ezproxy-lookup.admin_arn
 }

--- a/apps/ezproxy-lookup/main.tf
+++ b/apps/ezproxy-lookup/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = ">= 0.11.10"
+  required_version = ">= 0.12"
 
   backend "s3" {
     region         = "us-east-1"
@@ -16,5 +16,5 @@ terraform {
 }
 
 module "shared" {
-  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.11"
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
 }

--- a/apps/ezproxy-lookup/outputs.tf
+++ b/apps/ezproxy-lookup/outputs.tf
@@ -1,10 +1,10 @@
 output "access_key_id" {
-  value       = "${aws_iam_access_key.default.id}"
-  description = "The access key ID for app to use"
+  value       = aws_iam_access_key.default.id
+  description = "The access key ID for app to use."
 }
 
 output "secret_access_key" {
-  value       = "${aws_iam_access_key.default.secret}"
+  value       = aws_iam_access_key.default.secret
   sensitive   = true
-  description = "The secret access key for app to use. This will be written to the state file in plain-text"
+  description = "The secret access key for app to use. This will be written to the state file in plain-text."
 }


### PR DESCRIPTION
This is an upgrade of ezproxylookup to Terraform v0.12. If this app is deployed one change is made due to dynamic objects. Specifically, a new IAM access key is created. However, there are no other changes.