### PR TITLE
Solution to INFRA-75

### DIFF
--- a/apps/DIP/dip.tf
+++ b/apps/DIP/dip.tf
@@ -39,7 +39,7 @@ resource "aws_iam_access_key" "default" {
 module "aspace_s3" {
   source                 = "github.com/mitlibraries/tf-mod-s3-iam?ref=0.12"
   name                   = "aspace-oai-s3"
-  expire_objects_enabled = "true"
+  expire_objects_enabled = "false"
   expiration_days        = "60"
 }
 


### PR DESCRIPTION
Helen raised INFRA-75 concerning the retention of an individual file in
the aspace-oai-s3-stage bucket. The current tf-mod-s3-iam terraform
module does not support the ability to configure tag-based or index-
based retention/expiration policies. The temporary fix is to just
disable the retention rule completely for this S3 bucket until we can
upgrade the tf-mod-s3-iam module to allow for granular retention
policies.

There is only one change in this commit, but there is a larger impact
when this is deployed because it will create new credentials for the
three IAM users.

See the detailed notes on [INFRA-75](https://mitlibraries.atlassian.net/browse/INFRA-75?atlOrigin=eyJpIjoiNmE4NWE4M2YyOGIxNGYzY2I1NjBiODY3MTQ2ODVmMTAiLCJwIjoiaiJ9) for background and the plan for
addressing the AWS key/secret changes.