### PR TITLE
Initial ETD Bucket Configuration

### DIFF
--- a/apps/ETD/README.md
+++ b/apps/ETD/README.md
@@ -1,0 +1,55 @@
+# ETD
+
+## Ingest Bucket
+
+See Jira [ETD-83](https://mitlibraries.atlassian.net/browse/ETD-83?atlOrigin=eyJpIjoiMzU3OWZjYzcxNDdkNDJiMzgxMGM4NTRlYzc1MWIzZGMiLCJwIjoiaiJ9) for details of the original request in the context of the ETD project.
+
+The new thesis ingest process requires an S3 bucket for transient storage of ingested theses and related objects. The following general requirements were stated
+
+* Separate buckets for dev and test
+* CORS rules to allow Heroku apps to access bucket for storage
+* IAM rules & keys (shared with EngX) to control access to bucket
+* backup/DR to recover files unintentionally modified outside of the standard workflow
+* expiration/deletion of objects to be handled by ETD workflow
+
+## What's Created
+
+* S3 bucket (NOT using our standard module)
+* Versioning rules for protecting objects in bucket
+* Storage tiering rules to move older content to less expensive storage tiers
+* CORS configured to allow access by Heroku app
+* IAM user with keys for programmatic access by Heroku app
+* IAM policy that restricts S3 bucket access to Heroku app
+
+## Access Control
+
+Access control policies should be reviewed in the future. Our current practice for S3 buckets is to use IAM policies on the users to be granted access. We might want to revisit S3 bucket policies in the future. For reference, see this AWS blog post: [IAM vs Bucket Policies](https://aws.amazon.com/blogs/security/iam-policies-and-bucket-policies-and-acls-oh-my-controlling-access-to-s3-resources/).
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| bucketname | The name of the thesis submit bucket | `string` | n/a | yes |
+| expiration\_days | Number of days after which to expunge the objects | `string` | `"90"` | no |
+| expire\_objects\_enabled | Specifies expiration lifecycle rule status. | `string` | `"false"` | no |
+| glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `string` | `"60"` | no |
+| glacier\_transition\_enabled | Specifies Glacier transition lifecycle rule status. | `string` | `"false"` | no |
+| mfadelete\_enabled | Flag to enable or disable the MFA\_Delete requirement | `string` | `"false"` | no |
+| noncurrent\_rules\_enabled | Specifies noncurrent lifecycle rule status. | `string` | `"false"` | no |
+| noncurrent\_version\_expiration\_days | (Optional) Specifies when noncurrent object versions expire. | `string` | `"90"` | no |
+| noncurrent\_version\_transition\_days | (Optional) Specifies when noncurrent object versions transitions | `string` | `"30"` | no |
+| region | AWS region to be used for resources | `string` | `"us-east-1"` | no |
+| s3\_acl | The ACL to apply to the thesis submit bucket | `string` | n/a | yes |
+| s3\_cors\_rule | The CORS rule for the bucket to allow cross-origin access | `any` | n/a | yes |
+| standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | `string` | `"30"` | no |
+| standard\_transition\_enabled | Specifies infrequent storage transition lifecycle rule status. | `string` | `"false"` | no |
+| versioning\_enabled | (Optional) A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket. | `string` | `"false"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| access\_key\_id | Access key ID for the Thesis Submit user |
+| iam\_user | Name of the IAM user with access to the Thesis Submit bucket |
+| secret\_access\_key | Secret access key for Thesis Submit user |
+| thesis\_submit\_s3\_bucket | ARN for Thesis Submit bucket. |

--- a/apps/ETD/main.tf
+++ b/apps/ETD/main.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = var.region
+}
+
+#Tell terraform to use the S3 bucket and DynamoDB we created
+terraform {
+
+  backend "s3" {
+    region         = "us-east-1"
+    bucket         = "mit-tfstates-state"
+    key            = "apps/ETD.tfstate"
+    dynamodb_table = "mit-tfstates-state-lock"
+    encrypt        = true
+  }
+}
+
+module "shared" {
+  source = "github.com/mitlibraries/tf-mod-shared-provider?ref=0.12"
+}

--- a/apps/ETD/outputs.tf
+++ b/apps/ETD/outputs.tf
@@ -1,0 +1,21 @@
+output "thesis_submit_s3_bucket" {
+  value       = aws_s3_bucket.default.arn
+  description = "ARN for Thesis Submit bucket."
+}
+
+output "iam_user" {
+  description = "Name of the IAM user with access to the Thesis Submit bucket"
+  value       = aws_iam_user.default.name
+}
+
+output "access_key_id" {
+  value       = aws_iam_access_key.default.id
+  description = "Access key ID for the Thesis Submit user"
+}
+
+output "secret_access_key" {
+  value       = aws_iam_access_key.default.secret
+  sensitive   = true
+  description = "Secret access key for Thesis Submit user"
+}
+

--- a/apps/ETD/s3.tf
+++ b/apps/ETD/s3.tf
@@ -1,0 +1,108 @@
+module "label" {
+  source = "github.com/mitlibraries/tf-mod-name?ref=0.12"
+  name   = "thesis-submit"
+}
+
+# Create the bucket with CORS, Versioning, and Lifecycle
+resource "aws_s3_bucket" "default" {
+  bucket = "${var.bucketname}-${terraform.workspace}"
+  acl    = var.s3_acl
+
+  dynamic "cors_rule" {
+    for_each = var.s3_cors_rule
+
+    content {
+      allowed_methods = cors_rule.value.allowed_methods
+      allowed_origins = cors_rule.value.allowed_origins
+      allowed_headers = lookup(cors_rule.value, "allowed_headers", null)
+      expose_headers  = lookup(cors_rule.value, "expose_headers", null)
+      max_age_seconds = lookup(cors_rule.value, "max_age_seconds", null)
+    }
+  }
+
+  versioning {
+    enabled    = var.versioning_enabled
+    mfa_delete = var.mfadelete_enabled
+  }
+
+  lifecycle_rule {
+    id      = "${module.label.name}-transfer-to-IA"
+    enabled = var.standard_transition_enabled
+
+    transition {
+      days          = var.standard_transition_days
+      storage_class = "STANDARD_IA"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "${module.label.name}-transfer-to-glacier"
+    enabled = var.glacier_transition_enabled
+
+    transition {
+      days          = var.glacier_transition_days
+      storage_class = "GLACIER"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "${module.label.name}-expire-object"
+    enabled = var.expire_objects_enabled
+
+    expiration {
+      days = var.expiration_days
+    }
+  }
+
+  lifecycle_rule {
+    id      = "${module.label.name}-noncurrent-rules"
+    enabled = var.noncurrent_rules_enabled
+
+    noncurrent_version_expiration {
+      days = var.noncurrent_version_expiration_days
+    }
+
+    noncurrent_version_transition {
+      days          = var.noncurrent_version_transition_days
+      storage_class = "GLACIER"
+    }
+  }
+
+  tags = module.label.tags
+
+}
+
+# Create the IAM user for access to bucket
+resource "aws_iam_user" "default" {
+  name          = "${module.label.name}-readwrite"
+  path          = "/"
+  force_destroy = "false"
+  tags          = module.label.tags
+}
+
+# Create the key/secret pair for the IAM user
+resource "aws_iam_access_key" "default" {
+  user = aws_iam_user.default.name
+}
+
+# Create the simple IAM policy document for read/write access to the bucket
+data "aws_iam_policy_document" "readwrite" {
+  statement {
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.default.arn, "${aws_s3_bucket.default.arn}/*"]
+    effect    = "Allow"
+  }
+}
+
+# Create the IAM policy itself (the JSON that AWS uses)
+resource "aws_iam_policy" "readwrite" {
+  name        = "${module.label.name}-readwrite"
+  description = "Policy to allow IAM user read/write access to ${module.label.name} S3 bucket"
+  policy      = data.aws_iam_policy_document.readwrite.json
+}
+
+# Attach the new IAM policy to the new IAM user
+resource "aws_iam_user_policy_attachment" "default_rw" {
+  user       = aws_iam_user.default.name
+  policy_arn = aws_iam_policy.readwrite.arn
+}

--- a/apps/ETD/s3.tf
+++ b/apps/ETD/s3.tf
@@ -25,6 +25,14 @@ resource "aws_s3_bucket" "default" {
     mfa_delete = var.mfadelete_enabled
   }
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   lifecycle_rule {
     id      = "${module.label.name}-transfer-to-IA"
     enabled = var.standard_transition_enabled

--- a/apps/ETD/variables.tf
+++ b/apps/ETD/variables.tf
@@ -1,0 +1,83 @@
+# AWS variables
+variable "region" {
+  description = "AWS region to be used for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+# S3 variables
+variable "bucketname" {
+  description = "The name of the thesis submit bucket"
+  type        = string
+}
+
+variable "s3_acl" {
+  description = "The ACL to apply to the thesis submit bucket"
+  type        = string
+}
+
+variable "s3_cors_rule" {
+  description = "The CORS rule for the bucket to allow cross-origin access"
+}
+
+variable "mfadelete_enabled" {
+  description = "Flag to enable or disable the MFA_Delete requirement"
+  type        = string
+  default     = "false"
+}
+
+variable "versioning_enabled" {
+  description = "(Optional) A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket."
+  type        = string
+  default     = "false"
+}
+
+variable "noncurrent_rules_enabled" {
+  description = "Specifies noncurrent lifecycle rule status."
+  type        = string
+  default     = "false"
+}
+
+variable "noncurrent_version_expiration_days" {
+  description = "(Optional) Specifies when noncurrent object versions expire."
+  default     = "90"
+}
+
+variable "noncurrent_version_transition_days" {
+  description = "(Optional) Specifies when noncurrent object versions transitions"
+  default     = "30"
+}
+
+variable "standard_transition_enabled" {
+  description = "Specifies infrequent storage transition lifecycle rule status."
+  type        = string
+  default     = "false"
+}
+
+variable "standard_transition_days" {
+  description = "Number of days to persist in the standard storage tier before moving to the infrequent access tier"
+  default     = "30"
+}
+
+variable "glacier_transition_enabled" {
+  description = "Specifies Glacier transition lifecycle rule status."
+  type        = string
+  default     = "false"
+}
+
+variable "glacier_transition_days" {
+  description = "Number of days after which to move the data to the glacier storage tier"
+  default     = "60"
+}
+
+variable "expire_objects_enabled" {
+  description = "Specifies expiration lifecycle rule status."
+  type        = string
+  default     = "false"
+}
+
+variable "expiration_days" {
+  description = "Number of days after which to expunge the objects"
+  default     = "90"
+}
+

--- a/apps/ETD/versions.tf
+++ b/apps/ETD/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12.29"
+}


### PR DESCRIPTION
The [ETD-83](https://mitlibraries.atlassian.net/browse/ETD-83?atlOrigin=eyJpIjoiZWNhYTQ3ZjQzMjEwNGQ4YTlkNGRmOGQ3YzJmODUzOWYiLCJwIjoiaiJ9) task in Jira requries an S3 bucket for storing ingested theses as
part of the new ETD process. This is the initial commit for that task.
This requires an S3 bucket, and IAM user, CORS rules, and
retention/expiration rules for the bucket.

See the README for details. This creates the bucket, IAM user, IAM rules, CORS rules, and content retention rules.

At this time, the `prod.tfvars` and `stage.tfvars` files have been upload to the **mit-tfvars** bucket in S3 (in the apps/ETD path). None of these resources currently exist in AWS because I have run `terraform destroy` after my initial testing to leave AWS in a clean slate for the code reviews.

You should be able to checkout the ETD branch from the repository and run `TF_WORKSPACE=stage terraform plan -var-file=stage.tfvars` to verify and `TF_WORKSPACE=stage terraform apply -var-file=stage.tfvars" to create these resources for your own testing.

I intentionally did not use the tf-mod-s3-iam module to create this S3 bucket since there might be expiration and/or versioning requests that module can't handle at this time.